### PR TITLE
add: CODEANDTRUST/clawcall — hands-on Twilio↔AI-agent telephony starter (Section 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Clone these instead of writing boilerplate from scratch.
 - [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)  Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs. **🟡 Intermediate**
 - [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)  Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers. **🟡 Intermediate**
 - [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)  Up-to-date 2025–2026 list of open-source TTS and voice-cloning models.
+- [CODEANDTRUST/clawcall](https://github.com/CODEANDTRUST/clawcall)  Self-hostable Twilio↔OpenClaw bridge that routes every inbound caller utterance through a full agent turn — STT (Deepgram) → `chat.send` → TTS (ElevenLabs) — with native tool access mid-call. MIT, TypeScript. **🟡 Intermediate**
 - [CorentinJ/Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning)  Classic 5-second voice cloning project for understanding TTS fundamentals. **🟡 Intermediate**
 
 ## 12. Datasets and benchmarks


### PR DESCRIPTION
## What this adds

[**CODEANDTRUST/clawcall**](https://github.com/CODEANDTRUST/clawcall) — added to **Section 11: GitHub starter repos and awesome lists**.

It's a self-hostable TypeScript bridge that puts Section 9 (Telephony & SIP) concepts into practice end-to-end:

- Twilio inbound call → Deepgram streaming STT → OpenClaw gateway `chat.send` → ElevenLabs TTS → Twilio playback
- Every caller utterance runs through a **full agent turn** with native tool access (calendar, memory, web search, etc.)
- Barge-in support via Deepgram speech detection
- MIT license, Node 20+, TypeScript

## Why Section 11

Section 11 collects hands-on starter repos readers can clone and run. clawcall is exactly that: a reference implementation that wires together Twilio (covered in Section 9) with a real self-hosted agent gateway, demonstrating the complete STT→LLM→TTS pipeline on actual phone calls.

Companion guide: https://www.codeandtrust.com/blog/openclaw-phone-calls

## Checklist

- [x] Single entry added, nothing else changed
- [x] Matches list format (bullet with link, description, difficulty badge)
- [x] Open source (MIT), English, maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new GitHub resource entry for a self-hostable Twilio↔OpenClaw bridge to the starter repos and awesome lists section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->