### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ You can't ship what you can't measure. **Voice-agent evaluation is fundamentally
 - [LiveKit: Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency): Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize. **🟡 Intermediate**
 - [Twilio: How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents): Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency. **🟢 Beginner**
 - [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk): Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation. **🟡 Intermediate**
-- [Future AGI](https://github.com/future-agi/future-agi): Open-source platform to simulate, evaluate, trace, guardrail, and optimize voice and AI agent apps in one feedback loop, with persona-driven simulation and 70+ eval metrics. **🟡 Intermediate**
+- [Future AGI](https://github.com/future-agi/future-agi): Open-source platform to simulate, evaluate, trace, guardrail, and optimize voice and AI agent apps in one feedback loop, with persona-driven simulation and 50+ eval metrics. **🟡 Intermediate**
 
 ## 15. Production, deployment, and scaling
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ You can't ship what you can't measure. **Voice-agent evaluation is fundamentally
 - [LiveKit  Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)  Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize. **🟡 Intermediate**
 - [Twilio  How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)  Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency. **🟢 Beginner**
 - [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)  Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation. **🟡 Intermediate**
+- [Future AGI](https://github.com/future-agi/future-agi)  Open-source platform to **simulate**, evaluate, trace, guardrail, and optimize voice and AI agent apps in one feedback loop, with persona-driven simulation and 70+ eval metrics. **🟡 Intermediate**
 
 ## 15. Production, deployment, and scaling
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -275,6 +275,7 @@
 - [LiveKit：Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)：每轮延迟（端到端、LLM TTFT、TTS TTFB）与优化切入点。**🟡 进阶**
 - [Twilio：How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)：2025 厂商中立文：主张业务结果指标优于单纯 WER/延迟。**🟢 入门**
 - [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)：开源语音 AI 仿真 SDK，用于测试 AI 智能体；可生成合成对话用于评测。**🟡 进阶**
+- [Future AGI](https://github.com/future-agi/future-agi)：开源平台，在同一反馈闭环中对语音与 AI 智能体应用进行仿真、评测、追踪、护栏与优化；支持基于人物画像的仿真与 50+ 评测指标。**🟡 进阶**
 
 ## 15. 生产、部署与扩展
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the **Evaluation and testing** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **Future AGI** resource entry under **“Evaluation and testing”**, with a link and overview of simulating, evaluating, tracing, guardrailing, and optimizing voice and AI agent apps, including persona-driven simulation and 70+ evaluation metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->