### PR TITLE
docs: fix README separators, dead links, and stale facts; add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+
+# Windows
+Thumbs.db
+Desktop.ini
+
+# Editors / IDEs
+.idea/
+.vscode/
+*.swp
+*~
+
+# Node tooling (link checkers, awesome-lint, etc.)
+node_modules/
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![Banner Image](banner.png)
 
-> [English version](./README.md) [中文版本](./README_zh.md)
+> English | [中文版本](./README_zh.md)
 
 > A curated, developer friendly learning path for building real-time voice AI agents from your first STT call to scaling production telephony.
 
-Voice AI has moved from research demos into shipping product in under three years. **The modern stack is converging around a clear pattern**: a real-time transport layer (WebRTC or telephony), a streaming pipeline of speech-to-text → LLM → text-to-speech, and a turn-taking model that decides when the agent should speak. This list is structured to mirror that learning order  start with the foundations, pick a framework, then drill into individual components and production concerns.
+Voice AI has moved from research demos into shipping product in under three years. **The modern stack is converging around a clear pattern**: a real-time transport layer (WebRTC or telephony), a streaming pipeline of speech-to-text → LLM → text-to-speech, and a turn-taking model that decides when the agent should speak. This list is structured to mirror that learning order: start with the foundations, pick a framework, then drill into individual components and production concerns.
 
-Resources are tagged **🟢 Beginner**, **🟡 Intermediate**, or **🔴 Advanced**. Prefer free official docs and vendor-neutral guides; flag where authors have commercial interests.
+Learning resources are tagged **🟢 Beginner**, **🟡 Intermediate**, or **🔴 Advanced** (blogs, podcasts, and communities in sections 17-19 are intentionally left untagged). Prefer free official docs and vendor-neutral guides; flag where authors have commercial interests.
 
 ---
 
@@ -22,11 +22,9 @@ Read top-to-bottom if you're brand new. The recommended path:
 
 ---
 
----
-
 ## 📘 Companion book: Voice Agents Handbook
 
-If you want this material in a tighter, opinionated, production-grade form, I wrote the **[Voice Agents Handbook](https://handbook.mahimai.ca)**: building production voice AI with LiveKit, plus appendices on choosing your stack and the LiveKit ecosystem beyond agents. Ships June 1, 2026 on Kindle.
+If you want this material in a tighter, opinionated, production-grade form, I wrote the **[Voice Agents Handbook](https://handbook.mahimai.ca)**: building production voice AI with LiveKit, plus appendices on choosing your stack and the LiveKit ecosystem beyond agents. Available now on Kindle (and in paperback).
 
 The README you're reading collects the field's best free resources. The book is the curated path through them, with the patterns I've used shipping voice agents for trade people, lawyers, and immigration consultants.
 
@@ -64,310 +62,310 @@ The README you're reading collects the field's best free resources. The book is 
 
 Start here. These resources establish the **mental model of the voice agent pipeline** and the latency budget you'll fight for the rest of your career.
 
-- [Voice AI & Voice Agents  An Illustrated Primer](https://voiceaiandvoiceagents.com/)  Kwindla Hultman Kramer's free, regularly-updated long-form primer. The de facto textbook for the field. **🟢 Beginner**
-- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained (LiveKit)](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained)  Visual walkthrough of streaming patterns, turn detection, and where latency accumulates. **🟢 Beginner**
-- [Everything You Need to Know About Voice AI Agents (Deepgram)](https://deepgram.com/learn/everything-about-voice-ai-agents)  End-to-end primer covering feature extraction, ASR, LLM reasoning, and synthesis. **🟢 Beginner**
-- [AI Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/voice-agent/)  The canonical "what is a voice agent" reference, covering pipeline vs multimodal and agent state. **🟢 Beginner**
-- [Core Latency in AI Voice Agents (Twilio)](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents)  Visual explanation of end-of-turn detection, silence thresholds, and smart endpointing. **🟢 Beginner**
-- [Advice on Building Voice AI in June 2025 (Daily.co)](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/)  Practical P50/P95 latency-budget guidance from Pipecat's creators. **🟡 Intermediate**
-- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents (AssemblyAI)](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent)  Endpointing is the most underestimated problem; this is the clearest deep-dive. **🟡 Intermediate**
+- [Voice AI & Voice Agents: An Illustrated Primer](https://voiceaiandvoiceagents.com/): Kwindla Hultman Kramer's free, regularly-updated long-form primer. The de facto textbook for the field. **🟢 Beginner**
+- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained (LiveKit)](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained): Visual walkthrough of streaming patterns, turn detection, and where latency accumulates. **🟢 Beginner**
+- [Everything You Need to Know About Voice AI Agents (Deepgram)](https://deepgram.com/learn/everything-about-voice-ai-agents): End-to-end primer covering feature extraction, ASR, LLM reasoning, and synthesis. **🟢 Beginner**
+- [AI Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/voice-agent/): The canonical "what is a voice agent" reference, covering pipeline vs multimodal and agent state. **🟢 Beginner**
+- [Core Latency in AI Voice Agents (Twilio)](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents): Visual explanation of end-of-turn detection, silence thresholds, and smart endpointing. **🟢 Beginner**
+- [Advice on Building Voice AI in June 2025 (Daily.co)](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/): Practical P50/P95 latency-budget guidance from Pipecat's creators. **🟡 Intermediate**
+- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents (AssemblyAI)](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent): Endpointing is the most underestimated problem; this is the clearest deep-dive. **🟡 Intermediate**
 
 ## 2. Frameworks and orchestration platforms
 
 The frameworks below all let you wire STT, an LLM, and TTS together. **For open-source production work, LiveKit Agents and Pipecat are the two safest bets**; for managed dashboards, Vapi, Retell, and Bland win on time-to-first-call.
 
 ### Open-source frameworks
-- [LiveKit Agents  Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/)  Working assistant in <10 min via Python or TypeScript, runs on top of WebRTC. **🟢 Beginner**
-- [Pipecat  Quickstart](https://docs.pipecat.ai/getting-started/quickstart)  Scaffolds a Deepgram + OpenAI + Cartesia pipeline you can talk to in the browser in 5 minutes. **🟢 Beginner**
-- [Ultravox (fixie-ai/ultravox)](https://github.com/fixie-ai/ultravox)  Open-weight multimodal speech LLM (Llama/Gemma/Qwen variants) that skips the separate ASR stage for ~150 ms TTFT. **🔴 Advanced**
+- [LiveKit Agents: Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Working assistant in <10 min via Python or TypeScript, runs on top of WebRTC. **🟢 Beginner**
+- [Pipecat: Quickstart](https://docs.pipecat.ai/getting-started/quickstart): Scaffolds a Deepgram + OpenAI + Cartesia pipeline you can talk to in the browser in 5 minutes. **🟢 Beginner**
+- [Ultravox (fixie-ai/ultravox)](https://github.com/fixie-ai/ultravox): Open-weight multimodal speech LLM (Llama/Gemma/Qwen variants) that skips the separate ASR stage for ~150 ms TTFT. **🔴 Advanced**
 
 ### Managed platforms
-- [Vapi  Quickstart](https://docs.vapi.ai/quickstart/introduction)  Dashboard-first; ship an agent on a free US phone number in under 5 minutes. **🟢 Beginner**
-- [Retell AI  Introduction & Quickstart](https://docs.retellai.com/general/introduction)  Phone-agent platform with $10 free credit on signup. **🟢 Beginner**
-- [Bland AI  Send Your First Phone Call](https://docs.bland.ai/tutorials/send-first-call)  Minimal API tutorial for placing your first AI phone call. **🟢 Beginner**
-- [ElevenLabs Conversational AI  Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart)  Build and embed a voice agent widget on any website in 5 minutes. **🟢 Beginner**
+- [Vapi: Quickstart](https://docs.vapi.ai/quickstart/introduction): Dashboard-first; ship an agent on a free US phone number in under 5 minutes. **🟢 Beginner**
+- [Retell AI: Introduction & Quickstart](https://docs.retellai.com/general/introduction): Phone-agent platform with $10 free credit on signup. **🟢 Beginner**
+- [Bland AI: Send Your First Phone Call](https://docs.bland.ai/tutorials/send-first-call): Minimal API tutorial for placing your first AI phone call. **🟢 Beginner**
+- [ElevenLabs Conversational AI: Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart): Build and embed a voice agent widget on any website in 5 minutes. **🟢 Beginner**
 
 ### Realtime / speech-to-speech APIs
-- [OpenAI Realtime API  Guide](https://platform.openai.com/docs/guides/realtime)  Official guide to `gpt-realtime` over WebRTC, WebSockets, or SIP. **🟡 Intermediate**
-- [Google Gemini Live API  Overview](https://ai.google.dev/gemini-api/docs/live-api)  Low-latency, bidirectional voice + vision agents with barge-in and tool use. **🟡 Intermediate**
-- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay)  WebSocket bridge that handles STT/TTS so you focus on LLM logic; works with any LLM. **🟡 Intermediate**
+- [OpenAI Realtime API: Guide](https://platform.openai.com/docs/guides/realtime): Official guide to `gpt-realtime` over WebRTC, WebSockets, or SIP. **🟡 Intermediate**
+- [Google Gemini Live API: Overview](https://ai.google.dev/gemini-api/docs/live-api): Low-latency, bidirectional voice + vision agents with barge-in and tool use. **🟡 Intermediate**
+- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay): WebSocket bridge that handles STT/TTS so you focus on LLM logic; works with any LLM. **🟡 Intermediate**
 
 ### Vendor-neutral comparisons
-- [Vapi vs Pipecat vs LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit)  Architecture-focused comparison of pipeline control and transport choices. **🟡 Intermediate**
-- [11 Voice Agent Platforms Compared (Softcery)](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025)  Broad market map with use-case recommendations. **🟢 Beginner**
-- [Best Voice Agent Stack (Hamming AI)](https://hamming.ai/resources/best-voice-agent-stack)  Buy-vs-build framework with concrete cost, latency, and time-to-launch numbers. **🟡 Intermediate**
+- [Vapi vs Pipecat vs LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit): Architecture-focused comparison of pipeline control and transport choices. **🟡 Intermediate**
+- [11 Voice Agent Platforms Compared (Softcery)](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025): Broad market map with use-case recommendations. **🟢 Beginner**
+- [Best Voice Agent Stack (Hamming AI)](https://hamming.ai/resources/best-voice-agent-stack): Buy-vs-build framework with concrete cost, latency, and time-to-launch numbers. **🟡 Intermediate**
 
 ## 3. Speech-to-text (STT / ASR)
 
 Pick **one streaming STT** and learn it deeply before shopping around. Deepgram, AssemblyAI, and Whisper-derivatives cover most use cases.
 
 ### Commercial APIs
-- [Deepgram Nova-3  STT benchmarks](https://deepgram.com/learn/speech-to-text-benchmarks)  Primer on WER, latency, and cost alongside Deepgram's product reference. **🟢 Beginner**
-- [AssemblyAI Universal-Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling)  Streaming STT walkthrough that doubles as a function-calling tutorial. **🟡 Intermediate**
-- [OpenAI Whisper / gpt-4o-transcribe API docs](https://platform.openai.com/docs/guides/speech-to-text)  Easiest cloud STT if you already use OpenAI. **🟢 Beginner**
-- [Soniox multilingual benchmark](https://soniox.com/benchmarks)  Public WER comparison across 60 languages. **🟢 Beginner**
-- [Cartesia Ink](https://docs.cartesia.ai/)  Streaming STT paired with Sonic TTS for a single-vendor low-latency stack. **🟢 Beginner**
+- [Deepgram Nova-3: STT benchmarks](https://deepgram.com/learn/speech-to-text-benchmarks): Primer on WER, latency, and cost alongside Deepgram's product reference. **🟢 Beginner**
+- [AssemblyAI Universal-Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling): Streaming STT walkthrough that doubles as a function-calling tutorial. **🟡 Intermediate**
+- [OpenAI Whisper / gpt-4o-transcribe API docs](https://platform.openai.com/docs/guides/speech-to-text): Easiest cloud STT if you already use OpenAI. **🟢 Beginner**
+- [Soniox multilingual benchmark](https://soniox.com/benchmarks): Public WER comparison across 60 languages. **🟢 Beginner**
+- [Cartesia Ink](https://docs.cartesia.ai/): Streaming STT paired with Sonic TTS for a single-vendor low-latency stack. **🟢 Beginner**
 
 ### Open source
-- [openai/whisper](https://github.com/openai/whisper)  The original repo and the de facto starting point for any DIY ASR project. **🟢 Beginner**
-- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper)  CTranslate2 reimplementation up to 4× faster with INT8; recommended for self-hosted Whisper. **🟡 Intermediate**
-- [NVIDIA NeMo (Parakeet / Canary)](https://github.com/NVIDIA-NeMo/NeMo)  Top-of-leaderboard open ASR models with streaming inference recipes. **🔴 Advanced**
-- [Moonshine](https://github.com/moonshine-ai/moonshine)  Tiny on-device ASR (~190 MB) optimized for live streaming on edge devices. **🟡 Intermediate**
+- [openai/whisper](https://github.com/openai/whisper): The original repo and the de facto starting point for any DIY ASR project. **🟢 Beginner**
+- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper): CTranslate2 reimplementation up to 4× faster with INT8; recommended for self-hosted Whisper. **🟡 Intermediate**
+- [NVIDIA NeMo (Parakeet / Canary)](https://github.com/NVIDIA-NeMo/NeMo): Top-of-leaderboard open ASR models with streaming inference recipes. **🔴 Advanced**
+- [Moonshine](https://github.com/moonshine-ai/moonshine): Tiny on-device ASR (tiny 27M / base 61M params) optimized for live streaming on edge devices. **🟡 Intermediate**
 
 ### Benchmarks and explainers
-- [Open ASR Leaderboard (HuggingFace)](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)  Community leaderboard across 11 datasets  your reference for open-source picks. **🟢 Beginner**
-- [Artificial Analysis  Speech-to-Text](https://artificialanalysis.ai/speech-to-text)  Independent leaderboard ranking 48+ STT providers by WER, speed, and cost. **🟢 Beginner**
-- [Streaming vs Batch ASR (Arun Baby)](https://www.arunbaby.com/speech-tech/0001-streaming-asr/)  Engineer-friendly explainer of RNN-T and Conformer streaming architectures. **🟡 Intermediate**
+- [Open ASR Leaderboard (HuggingFace)](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Community leaderboard across 11 datasets: your reference for open-source picks. **🟢 Beginner**
+- [Artificial Analysis: Speech-to-Text](https://artificialanalysis.ai/speech-to-text): Independent leaderboard ranking 48+ STT providers by WER, speed, and cost. **🟢 Beginner**
+- [Streaming vs Batch ASR (Arun Baby)](https://www.arunbaby.com/speech-tech/0001-streaming-asr/): Engineer-friendly explainer of RNN-T and Conformer streaming architectures. **🟡 Intermediate**
 
 ## 4. Text-to-speech (TTS)
 
-**Latency, not raw quality, is what kills voice agents**  prioritize providers offering true streaming with first-byte under 200 ms.
+**Latency, not raw quality, is what kills voice agents**: prioritize providers offering true streaming with first-byte under 200 ms.
 
 ### Commercial APIs
-- [ElevenLabs Docs](https://elevenlabs.io/docs)  Industry-leading quality, voice cloning, and Conversational AI in one SDK. **🟢 Beginner**
-- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/get-started/quickstart)  Sub-100 ms first-byte latency, designed specifically for voice agents. **🟢 Beginner**
-- [Deepgram Aura](https://developers.deepgram.com/docs/tts-models)  Low-latency streaming TTS that pairs cleanly with Deepgram STT. **🟢 Beginner**
-- [OpenAI TTS (gpt-4o-mini-tts)](https://platform.openai.com/docs/guides/text-to-speech)  Easiest plug-in TTS for the OpenAI stack. **🟢 Beginner**
-- [Artificial Analysis  TTS leaderboard](https://artificialanalysis.ai/text-to-speech/models)  ELO, price, and speed comparison covering Rime, PlayHT, Hume, Inworld, and others. **🟢 Beginner**
+- [ElevenLabs Docs](https://elevenlabs.io/docs): Industry-leading quality, voice cloning, and Conversational AI in one SDK. **🟢 Beginner**
+- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/get-started/realtime-text-to-speech-quickstart): Sub-100 ms first-byte latency, designed specifically for voice agents. **🟢 Beginner**
+- [Deepgram Aura](https://developers.deepgram.com/docs/tts-models): Low-latency streaming TTS that pairs cleanly with Deepgram STT. **🟢 Beginner**
+- [OpenAI TTS (gpt-4o-mini-tts)](https://platform.openai.com/docs/guides/text-to-speech): Easiest plug-in TTS for the OpenAI stack. **🟢 Beginner**
+- [Artificial Analysis: TTS leaderboard](https://artificialanalysis.ai/text-to-speech/models): ELO, price, and speed comparison covering Rime, PlayHT, Hume, Inworld, and others. **🟢 Beginner**
 
 ### Open source
-- [Coqui TTS (idiap fork)](https://github.com/idiap/coqui-ai-TTS)  Maintained fork of Coqui-TTS / XTTS v2; the most battle-tested OSS TTS toolkit. **🟡 Intermediate**
-- [Piper (OHF-Voice/piper1-gpl)](https://github.com/OHF-Voice/piper1-gpl)  Fast local neural TTS optimized for Raspberry Pi; perfect for offline projects. **🟢 Beginner**
-- [Kokoro 82M](https://github.com/hexgrad/kokoro)  Tiny Apache-licensed model that tops community ELO arenas; runs on CPU. **🟢 Beginner**
-- [F5-TTS](https://github.com/SWivid/F5-TTS)  Diffusion-transformer TTS with high-quality zero-shot voice cloning. **🟡 Intermediate**
-- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS)  Llama-3B-based emotive TTS with ~200 ms streaming and emotion tags. **🟡 Intermediate**
-- [Sesame CSM](https://github.com/SesameAILabs/csm)  Conversational, context-aware multi-speaker TTS using a Llama backbone with the Mimi codec. **🔴 Advanced**
+- [Coqui TTS (idiap fork)](https://github.com/idiap/coqui-ai-TTS): Maintained fork of Coqui-TTS / XTTS v2; the most battle-tested OSS TTS toolkit. **🟡 Intermediate**
+- [Piper (OHF-Voice/piper1-gpl)](https://github.com/OHF-Voice/piper1-gpl): Fast local neural TTS optimized for Raspberry Pi; perfect for offline projects. **🟢 Beginner**
+- [Kokoro 82M](https://github.com/hexgrad/kokoro): Tiny Apache-licensed model that tops community ELO arenas; runs on CPU. **🟢 Beginner**
+- [F5-TTS](https://github.com/SWivid/F5-TTS): Diffusion-transformer TTS with high-quality zero-shot voice cloning. **🟡 Intermediate**
+- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS): Llama-3B-based emotive TTS with ~200 ms streaming and emotion tags. **🟡 Intermediate**
+- [Sesame CSM](https://github.com/SesameAILabs/csm): Conversational, context-aware multi-speaker TTS using a Llama backbone with the Mimi codec. **🔴 Advanced**
 
 ### Streaming and ethics
-- [Streaming TTS for Low-Latency Agents (Picovoice)](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/)  Clear taxonomy of single, output-streaming, and dual-streaming TTS. **🟡 Intermediate**
-- [Ethics of Voice Cloning & Deepfakes (Deepgram)](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes)  Vendor-neutral discussion of misuse, regulation, and developer responsibility. **🟢 Beginner**
+- [Streaming TTS for Low-Latency Agents (Picovoice)](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/): Clear taxonomy of single, output-streaming, and dual-streaming TTS. **🟡 Intermediate**
+- [Ethics of Voice Cloning & Deepfakes (Deepgram)](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes): Vendor-neutral discussion of misuse, regulation, and developer responsibility. **🟢 Beginner**
 
 ## 5. LLMs for voice and real-time AI
 
 A voice agent's perceived intelligence is bounded by **how fast the LLM streams its first token**. Sub-300 ms TTFT changes the conversation feel entirely.
 
 ### Low-latency inference
-- [Groq](https://groq.com/)  LPU-based inference cloud delivering ~10× faster Llama tokens/sec than commodity GPUs. **🟢 Beginner**
-- [Cerebras Inference](https://www.cerebras.ai/inference)  Wafer-scale chip inference with very high throughput on Llama models. **🟢 Beginner**
-- [SambaNova Cloud](https://cloud.sambanova.ai/)  Reconfigurable Dataflow inference; stable throughput at low latency. **🟢 Beginner**
+- [Groq](https://groq.com/): LPU-based inference cloud delivering ~10× faster Llama tokens/sec than commodity GPUs. **🟢 Beginner**
+- [Cerebras Inference](https://www.cerebras.ai/inference): Wafer-scale chip inference with very high throughput on Llama models. **🟢 Beginner**
+- [SambaNova Cloud](https://cloud.sambanova.ai/): Reconfigurable Dataflow inference; stable throughput at low latency. **🟢 Beginner**
 
 ### Speech-to-speech models
-- [OpenAI Realtime API guide](https://platform.openai.com/docs/guides/realtime)  Flagship S2S product with WebRTC/WebSocket transport. **🟡 Intermediate**
-- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api)  Real-time multimodal voice/video with barge-in and 70-language support. **🟡 Intermediate**
-- [Moshi (kyutai-labs)](https://github.com/kyutai-labs/moshi)  Open-source full-duplex speech-text foundation model with 200 ms latency  the premier OSS S2S model to study. **🔴 Advanced**
+- [OpenAI Realtime API guide](https://platform.openai.com/docs/guides/realtime): Flagship S2S product with WebRTC/WebSocket transport. **🟡 Intermediate**
+- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api): Real-time multimodal voice/video with barge-in and 70-language support. **🟡 Intermediate**
+- [Moshi (kyutai-labs)](https://github.com/kyutai-labs/moshi): Open-source full-duplex speech-text foundation model with 200 ms latency: the premier OSS S2S model to study. **🔴 Advanced**
 
 ### Voice-specific prompting and tools
-- [OpenAI Voice Agents Guide](https://platform.openai.com/docs/guides/voice-agents)  Compares chained vs S2S architectures with prompt and tool best practices. **🟢 Beginner**
-- [ElevenLabs Voice Agent Prompting Guide](https://elevenlabs.io/docs/conversational-ai/best-practices/prompting-guide)  Production-grade prompt structure tuned for voice; vendor-neutral lessons. **🟡 Intermediate**
-- [Voice AI Prompt Engineering Guide (VoiceInfra)](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide)  Explains why voice prompts must be 60–70% shorter than chat prompts, with templates. **🟢 Beginner**
-- [Function Calling for Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/voice-agent/function-calling/)  Concise guide to defining tools and RPC inside a voice agent. **🟡 Intermediate**
+- [OpenAI Voice Agents Guide](https://platform.openai.com/docs/guides/voice-agents): Compares chained vs S2S architectures with prompt and tool best practices. **🟢 Beginner**
+- [ElevenLabs Voice Agent Prompting Guide](https://elevenlabs.io/docs/agents-platform/best-practices/prompting-guide): Production-grade prompt structure tuned for voice; vendor-neutral lessons. **🟡 Intermediate**
+- [Voice AI Prompt Engineering Guide (VoiceInfra)](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide): Explains why voice prompts must be 60–70% shorter than chat prompts, with templates. **🟢 Beginner**
+- [Function Calling for Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/voice-agent/function-calling/): Concise guide to defining tools and RPC inside a voice agent. **🟡 Intermediate**
 
 ## 6. Voice activity detection and turn-taking
 
-Pure VAD is no longer enough  modern agents combine **acoustic VAD with a small semantic model** that predicts end-of-utterance from words and prosody.
+Pure VAD is no longer enough: modern agents combine **acoustic VAD with a small semantic model** that predicts end-of-utterance from words and prosody.
 
-- [Silero VAD](https://github.com/snakers4/silero-vad)  MIT-licensed pre-trained VAD; <1 ms per chunk on CPU. The de facto VAD inside LiveKit and Pipecat. **🟢 Beginner**
-- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad)  Python bindings for Google's classic WebRTC VAD; lightweight baseline. **🟢 Beginner**
-- [LiveKit Turn Detector  blog post](https://blog.livekit.io/using-a-transformer-to-improve-end-of-turn-detection)  How a SmolLM-based EOU model complements VAD with semantic context. **🟡 Intermediate**
-- [LiveKit turn-detector model on HuggingFace](https://huggingface.co/livekit/turn-detector)  Open-weights multilingual EOU model running ONNX on CPU in under 500 MB. **🟡 Intermediate**
-- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/)  Whisper-Tiny-based audio semantic VAD with 12 ms CPU inference, BSD-2 licensed. **🟡 Intermediate**
-- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn)  Repo with model code, training scripts, and integration examples. **🟡 Intermediate**
-- [The Complete Guide to AI Turn-Taking (Tavus)](https://www.tavus.io/post/ai-turn-taking)  Reader-friendly overview of why pure VAD fails in real conversations. **🟢 Beginner**
-- [Tackling Turn Detection in Voice AI (Notch)](https://www.notch.cx/post/turn-detection-in-voice-ai)  Engineer-first walkthrough combining VAD probability, volume, and TTS markers. **🟡 Intermediate**
-- [ai-coustics VAD](https://developers.ai-coustics.com/)  VAD bundled with real-time speech enhancement, noise suppression, and voice isolation in a single audio preprocessing SDK; useful when you want cleanup and turn-taking signals from the same component. **🟢 Beginner**
+- [Silero VAD](https://github.com/snakers4/silero-vad): MIT-licensed pre-trained VAD; <1 ms per chunk on CPU. The de facto VAD inside LiveKit and Pipecat. **🟢 Beginner**
+- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad): Python bindings for Google's classic WebRTC VAD; lightweight baseline. **🟢 Beginner**
+- [LiveKit Turn Detector: blog post](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection): How a small transformer-based EOU model complements VAD with semantic context. **🟡 Intermediate**
+- [LiveKit turn-detector model on HuggingFace](https://huggingface.co/livekit/turn-detector): Open-weights multilingual EOU model running ONNX on CPU in under 500 MB. **🟡 Intermediate**
+- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/): Whisper-Tiny-based audio semantic VAD with 12 ms CPU inference, BSD-2 licensed. **🟡 Intermediate**
+- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn): Repo with model code, training scripts, and integration examples. **🟡 Intermediate**
+- [The Complete Guide to AI Turn-Taking (Tavus)](https://www.tavus.io/blog/ai-turn-taking): Reader-friendly overview of why pure VAD fails in real conversations. **🟢 Beginner**
+- [Tackling Turn Detection in Voice AI (Notch)](https://www.notch.cx/post/turn-detection-in-voice-ai): Engineer-first walkthrough combining VAD probability, volume, and TTS markers. **🟡 Intermediate**
+- [ai-coustics VAD](https://developers.ai-coustics.com/): VAD bundled with real-time speech enhancement, noise suppression, and voice isolation in a single audio preprocessing SDK; useful when you want cleanup and turn-taking signals from the same component. **🟢 Beginner**
 
 ## 7. Audio enhancement and noise suppression
 
 The audio reaching your VAD and STT is often noisy, reverberant, or mixed with background voices. **Cleaning the signal before the rest of the pipeline** is frequently the difference between an agent that ships and one that frustrates users in real-world conditions (cars, cafés, call centres).
 
-- [ai-coustics](https://ai-coustics.com/)  Real-time speech enhancement SDK covering noise cancellation, voice isolation, and VAD; on-device and cloud deployment. See the [docs](https://docs.ai-coustics.com/) and [developer platform](https://developers.ai-coustics.com/). **🟢 Beginner**
+- [ai-coustics](https://ai-coustics.com/): Real-time speech enhancement SDK covering noise cancellation, voice isolation, and VAD; on-device and cloud deployment. See the [docs](https://docs.ai-coustics.com/) and [developer platform](https://developers.ai-coustics.com/). **🟢 Beginner**
 
 ## 8. WebRTC fundamentals
 
 WebRTC is the **default transport for voice agents** that don't run over the phone network. Understanding ICE, STUN, TURN, and SFU architecture is non-negotiable for production work.
 
-- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)  Authoritative free reference for `RTCPeerConnection`, `getUserMedia`, and signaling. **🟢 Beginner**
-- [MDN: Introduction to WebRTC Protocols](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols)  Beginner-friendly explanation of ICE, STUN, TURN, and SDP. **🟢 Beginner**
-- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview)  Official Google-maintained intro, splitting WebRTC into media-capture and connectivity. **🟢 Beginner**
-- [GetStream  WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/)  Free multi-module tutorial covering networking basics through advanced topics. **🟢 Beginner**
-- [Why WebRTC Beats WebSockets for Voice AI (LiveKit)](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents)  2025 explainer aimed at AI builders, comparing transports in plain English. **🟡 Intermediate**
-- [Daily Docs  Intro to Video Architecture (P2P vs SFU)](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch)  One of the clearest beginner write-ups of P2P vs SFU. **🟢 Beginner**
-- [Agora  How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/)  Side-by-side WebRTC vs WebSockets walkthrough with signaling diagrams. **🟢 Beginner**
+- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API): Authoritative free reference for `RTCPeerConnection`, `getUserMedia`, and signaling. **🟢 Beginner**
+- [MDN: Introduction to WebRTC Protocols](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols): Beginner-friendly explanation of ICE, STUN, TURN, and SDP. **🟢 Beginner**
+- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview): Official Google-maintained intro, splitting WebRTC into media-capture and connectivity. **🟢 Beginner**
+- [GetStream: WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/): Free multi-module tutorial covering networking basics through advanced topics. **🟢 Beginner**
+- [Why WebRTC Beats WebSockets for Voice AI (LiveKit)](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents): 2025 explainer aimed at AI builders, comparing transports in plain English. **🟡 Intermediate**
+- [Daily Docs: Intro to Video Architecture (P2P vs SFU)](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch): One of the clearest beginner write-ups of P2P vs SFU. **🟢 Beginner**
+- [Agora: How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/): Side-by-side WebRTC vs WebSockets walkthrough with signaling diagrams. **🟢 Beginner**
 
 ## 9. Telephony and SIP
 
 The phone network has its own physics. Once you know which **SIP trunk provider** to point at LiveKit or Pipecat, you can ship.
 
-- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice)  TwiML, Voice API, and PSTN connectivity in one hub; the default starting point. **🟢 Beginner**
-- [Twilio: Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python)  Step-by-step junior-friendly tutorial wiring Twilio Media Streams to an LLM. **🟢 Beginner**
-- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart)  Clearest beginner explainer of SIP basics, SIP Domains, and softphone setup. **🟢 Beginner**
-- [Telnyx Voice API](https://telnyx.com/products/voice-api)  Strong Twilio alternative with WebSocket media streaming and an AI Assistant tooling. **🟢 Beginner**
-- [Telnyx  How to Set Up a SIP Trunk](https://telnyx.com/resources/how-to-setup-sip-trunk)  Friendly walkthrough of SIP trunking architecture, codecs, and authentication. **🟢 Beginner**
-- [Plivo Voice API Documentation](https://www.plivo.com/docs/voice/)  XML call control and audio-streaming integrations for AI agents. **🟢 Beginner**
-- [SignalWire Voice Docs](https://developer.signalwire.com/voice/)  Built on FreeSWITCH; SWML, TwiML-compatible API, and an AI Agents SDK. **🟡 Intermediate**
-- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/)  Best diagram of how a call flows from PSTN → trunk → SIP service → agent. **🟢 Beginner**
-- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/)  Practical guide for wiring Twilio/Telnyx/Plivo trunks into LiveKit. **🟡 Intermediate**
-- [Pipecat Telephony Overview](https://docs.pipecat.ai/guides/telephony/overview)  Differences between WebSocket-based telephony and SIP-based call control. **🟡 Intermediate**
+- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice): TwiML, Voice API, and PSTN connectivity in one hub; the default starting point. **🟢 Beginner**
+- [Twilio: Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python): Step-by-step junior-friendly tutorial wiring Twilio Media Streams to an LLM. **🟢 Beginner**
+- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart): Clearest beginner explainer of SIP basics, SIP Domains, and softphone setup. **🟢 Beginner**
+- [Telnyx Voice API](https://telnyx.com/products/voice-api): Strong Twilio alternative with WebSocket media streaming and AI Assistant tooling. **🟢 Beginner**
+- [Telnyx: How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk): Friendly walkthrough of SIP trunking architecture, codecs, and authentication. **🟢 Beginner**
+- [Plivo Voice API Documentation](https://www.plivo.com/docs/voice/): XML call control and audio-streaming integrations for AI agents. **🟢 Beginner**
+- [SignalWire Voice Docs](https://developer.signalwire.com/voice/): Built on FreeSWITCH; SWML, TwiML-compatible API, and an AI Agents SDK. **🟡 Intermediate**
+- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/): Best diagram of how a call flows from PSTN → trunk → SIP service → agent. **🟢 Beginner**
+- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/): Practical guide for wiring Twilio/Telnyx/Plivo trunks into LiveKit. **🟡 Intermediate**
+- [Pipecat Telephony Overview](https://docs.pipecat.ai/guides/telephony/overview): Differences between WebSocket-based telephony and SIP-based call control. **🟡 Intermediate**
 
 ## 10. Tutorials and hands-on projects
 
 Pick **one tutorial and finish it before starting another**. Voice AI is unforgiving of half-built pipelines.
 
-- [LiveKit Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/)  Official 10-minute walkthrough in Python or Node with starter templates. **🟢 Beginner**
-- [Build Your First AI Voice Agent in Python (LiveKit)](https://livekit.com/blog/build-your-first-ai-voice-agent-python)  End-to-end Python tutorial covering streaming, latency, and deployment. **🟢 Beginner**
-- [Pipecat Quickstart](https://docs.pipecat.ai/getting-started/quickstart)  Build and deploy a Deepgram + OpenAI + Cartesia bot in roughly 10 minutes. **🟢 Beginner**
-- [How to Build a Real-Time Voice Agent with Pipecat (AssemblyAI)](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat)  Production-oriented walkthrough including local testing and Pipecat Cloud deployment. **🟡 Intermediate**
-- [Deepgram  Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent)  Step-by-step guide wiring Deepgram STT, GPT, and Aura TTS. **🟢 Beginner**
-- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python)  Provider-agnostic tutorial supporting OpenAI, Anthropic, or DeepSeek. **🟡 Intermediate**
-- [freeCodeCamp  Build Advanced AI Agents (LiveKit, Exa, LangChain)](https://www.youtube.com/watch?v=B0TJC4lmzEM)  Free 3-part video course covering interactive voice agents end-to-end. **🟢 Beginner**
-- [freeCodeCamp  Private On-Device Voice Assistant](https://www.freecodecamp.org/news/private-voice-assistant-using-open-source-tools/)  Hands-on local stack with Whisper, a local LLM, and system TTS. **🟡 Intermediate**
+- [LiveKit Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Official 10-minute walkthrough in Python or Node with starter templates. **🟢 Beginner**
+- [Build Your First AI Voice Agent in Python (LiveKit)](https://livekit.com/blog/build-your-first-ai-voice-agent-python): End-to-end Python tutorial covering streaming, latency, and deployment. **🟢 Beginner**
+- [Pipecat Quickstart](https://docs.pipecat.ai/getting-started/quickstart): Build and deploy a Deepgram + OpenAI + Cartesia bot in roughly 10 minutes. **🟢 Beginner**
+- [How to Build a Real-Time Voice Agent with Pipecat (AssemblyAI)](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat): Production-oriented walkthrough including local testing and Pipecat Cloud deployment. **🟡 Intermediate**
+- [Deepgram: Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent): Step-by-step guide wiring Deepgram STT, GPT, and Aura TTS. **🟢 Beginner**
+- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python): Provider-agnostic tutorial supporting OpenAI, Anthropic, or DeepSeek. **🟡 Intermediate**
+- [freeCodeCamp: Build Advanced AI Agents (LiveKit, Exa, LangChain)](https://www.youtube.com/watch?v=B0TJC4lmzEM): Free 3-part video course covering interactive voice agents end-to-end. **🟢 Beginner**
+- [freeCodeCamp: Private On-Device Voice Assistant](https://www.freecodecamp.org/news/private-voice-assistant-using-open-source-tools/): Hands-on local stack with Whisper, a local LLM, and system TTS. **🟡 Intermediate**
 
 ## 11. GitHub starter repos and awesome lists
 
 Clone these instead of writing boilerplate from scratch.
 
-- [livekit/agents](https://github.com/livekit/agents)  The flagship open-source Python/Node framework for production voice agents. **🟢 → 🔴**
-- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat)  Vendor-neutral framework with 40+ STT/LLM/TTS service plugins. **🟢 → 🔴**
-- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python)  Production-ready starter with Dockerfile, eval suite, turn detector, and core plugins. **🟢 Beginner**
-- [livekit-examples (org)](https://github.com/livekit-examples)  Official collection of LiveKit Python/React/Swift/Android starters. **🟢 Beginner**
-- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples)  Sample apps for push-to-talk, websocket, telephony, and multimodal use cases. **🟢 → 🟡**
-- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples)  Runnable Next.js and Python examples for TTS, STT, and real-time agents. **🟢 Beginner**
-- [vocodedev/vocode-core](https://github.com/vocodedev/vocode-core)  Open-source modular framework for voice-LLM agents on phone, Zoom, or system audio. **🟡 Intermediate** *(less actively maintained than LiveKit/Pipecat)*
-- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)  Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs. **🟡 Intermediate**
-- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)  Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers. **🟡 Intermediate**
-- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)  Up-to-date 2025–2026 list of open-source TTS and voice-cloning models.
-- [CorentinJ/Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning)  Classic 5-second voice cloning project for understanding TTS fundamentals. **🟡 Intermediate**
+- [livekit/agents](https://github.com/livekit/agents): The flagship open-source Python/Node framework for production voice agents. **🟢 → 🔴**
+- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat): Vendor-neutral framework with 40+ STT/LLM/TTS service plugins. **🟢 → 🔴**
+- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python): Production-ready starter with Dockerfile, eval suite, turn detector, and core plugins. **🟢 Beginner**
+- [livekit-examples (org)](https://github.com/livekit-examples): Official collection of LiveKit Python/React/Swift/Android starters. **🟢 Beginner**
+- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples): Sample apps for push-to-talk, websocket, telephony, and multimodal use cases. **🟢 → 🟡**
+- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples): Runnable Next.js and Python examples for TTS, STT, and real-time agents. **🟢 Beginner**
+- [vocodedev/vocode-core](https://github.com/vocodedev/vocode-core): Open-source modular framework for voice-LLM agents on phone, Zoom, or system audio. **🟡 Intermediate** *(less actively maintained than LiveKit/Pipecat)*
+- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents): Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs. **🟡 Intermediate**
+- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers): Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers. **🟡 Intermediate**
+- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice): Up-to-date 2025–2026 list of open-source TTS and voice-cloning models. **🟢 Beginner**
+- [CorentinJ/Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning): Classic 5-second voice cloning project for understanding TTS fundamentals. **🟡 Intermediate**
 
 ## 12. Datasets and benchmarks
 
 You'll rarely train from scratch, but knowing **which dataset a model was trained on** explains its accents, languages, and failure modes.
 
-- [LibriSpeech ASR Corpus](https://www.openslr.org/12)  ~1,000 hours of English audiobooks; nearly every ASR paper benchmarks against it. **🟢 Beginner**
-- [Mozilla Common Voice](https://commonvoice.mozilla.org/)  Crowdsourced multilingual dataset (100+ languages); the easiest legal way to fine-tune ASR. **🟢 Beginner**
-- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0)  One-line `load_dataset()` access for hands-on experiments. **🟢 Beginner**
-- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)  Live comparison of 60+ ASR models on WER and real-time factor. **🟢 Beginner**
-- [Artificial Analysis  Speech](https://artificialanalysis.ai/speech-to-text)  Independent benchmarks of commercial STT and TTS providers. **🟢 Beginner**
-- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)  ~24 hours of single-speaker English audio; baseline corpus for Tacotron 2 and VITS. **🟢 Beginner**
-- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443)  ~110 English speakers with diverse accents; widely used for multi-speaker TTS. **🟡 Intermediate**
-- [VoxCeleb (Oxford VGG)](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/)  Million-utterance "in the wild" dataset for speaker identification and verification. **🟡 Intermediate**
+- [LibriSpeech ASR Corpus](https://www.openslr.org/12): ~1,000 hours of English audiobooks; nearly every ASR paper benchmarks against it. **🟢 Beginner**
+- [Mozilla Common Voice](https://commonvoice.mozilla.org/): Crowdsourced multilingual dataset (100+ languages); the easiest legal way to fine-tune ASR. **🟢 Beginner**
+- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0): One-line `load_dataset()` access for hands-on experiments. **🟢 Beginner**
+- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Live comparison of 60+ ASR models on WER and real-time factor. **🟢 Beginner**
+- [Artificial Analysis: Speech](https://artificialanalysis.ai/speech-to-text): Independent benchmarks of commercial STT and TTS providers. **🟢 Beginner**
+- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/): ~24 hours of single-speaker English audio; baseline corpus for Tacotron 2 and VITS. **🟢 Beginner**
+- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443): ~110 English speakers with diverse accents; widely used for multi-speaker TTS. **🟡 Intermediate**
+- [VoxCeleb (Oxford VGG)](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/): Million-utterance "in the wild" dataset for speaker identification and verification. **🟡 Intermediate**
 
 ## 13. Beginner-accessible research papers
 
-These are the **landmark papers behind the models you'll actually use**. Read the Whisper and Common Voice papers first  they're unusually approachable.
+These are the **landmark papers behind the models you'll actually use**. Read the Whisper and Common Voice papers first: they're unusually approachable.
 
-- [Whisper  Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356)  Behind the most popular open ASR model; unusually clear prose for an ML paper. **🟡 Intermediate**
-- [HuggingFace Whisper fine-tuning blog (companion)](https://huggingface.co/blog/fine-tune-whisper)  Hands-on walkthrough that lets you "feel" the Whisper paper in code. **🟢 Beginner**
-- [VITS  Conditional VAE with Adversarial Learning for End-to-End TTS (2021)](https://arxiv.org/abs/2106.06103)  The single-stage TTS model behind many open-source voice cloners. **🟡 Intermediate**
-- [Tacotron 2  Natural TTS Synthesis (2017)](https://arxiv.org/abs/1712.05884)  Landmark seq2seq + WaveNet-vocoder paper that made neural TTS sound natural. **🟡 Intermediate**
-- [Conformer  Convolution-augmented Transformer for ASR (2020)](https://arxiv.org/abs/2005.08100)  The architecture inside NVIDIA Parakeet, Canary, and many leaderboard models. **🟡 Intermediate**
-- [wav2vec 2.0  Self-Supervised Learning of Speech Representations (2020)](https://arxiv.org/abs/2006.11477)  Showed that pretraining on unlabeled audio drastically reduces labeled-data needs. **🟡 Intermediate**
-- [Common Voice  A Massively-Multilingual Speech Corpus (2020)](https://arxiv.org/abs/1912.06670)  Short, accessible paper describing how Common Voice is built and validated. **🟢 Beginner**
-- [Open ASR Leaderboard preprint (2025)](https://arxiv.org/abs/2510.06961)  Reproducible benchmark of 60+ ASR models across 11 datasets; the modern landscape map. **🟡 Intermediate**
+- [Whisper: Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356): Behind the most popular open ASR model; unusually clear prose for an ML paper. **🟡 Intermediate**
+- [HuggingFace Whisper fine-tuning blog (companion)](https://huggingface.co/blog/fine-tune-whisper): Hands-on walkthrough that lets you "feel" the Whisper paper in code. **🟢 Beginner**
+- [VITS: Conditional VAE with Adversarial Learning for End-to-End TTS (2021)](https://arxiv.org/abs/2106.06103): The single-stage TTS model behind many open-source voice cloners. **🟡 Intermediate**
+- [Tacotron 2: Natural TTS Synthesis (2017)](https://arxiv.org/abs/1712.05884): Landmark seq2seq + WaveNet-vocoder paper that made neural TTS sound natural. **🟡 Intermediate**
+- [Conformer: Convolution-augmented Transformer for ASR (2020)](https://arxiv.org/abs/2005.08100): The architecture inside NVIDIA Parakeet, Canary, and many leaderboard models. **🟡 Intermediate**
+- [wav2vec 2.0: Self-Supervised Learning of Speech Representations (2020)](https://arxiv.org/abs/2006.11477): Showed that pretraining on unlabeled audio drastically reduces labeled-data needs. **🟡 Intermediate**
+- [Common Voice: A Massively-Multilingual Speech Corpus (2020)](https://arxiv.org/abs/1912.06670): Short, accessible paper describing how Common Voice is built and validated. **🟢 Beginner**
+- [Open ASR Leaderboard preprint (2025)](https://arxiv.org/abs/2510.06961): Reproducible benchmark of 60+ ASR models across 11 datasets; the modern landscape map. **🟡 Intermediate**
 
 ## 14. Evaluation and testing
 
-You can't ship what you can't measure. **Voice-agent evaluation is fundamentally probabilistic**  a single transcript can pass and fail across runs, so simulation and statistics matter more than fixed test cases.
+You can't ship what you can't measure. **Voice-agent evaluation is fundamentally probabilistic**: a single transcript can pass and fail across runs, so simulation and statistics matter more than fixed test cases.
 
-- [Coval  Voice AI Testing Platform](https://www.coval.dev/voice-ai-testing)  Defines the core voice-agent metrics: TTFB, WER, resolution rate, simulated accents, and interruptions. **🟢 Beginner**
-- [Coval  How to Evaluate Voice Agents (Practical Guide)](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance)  One of the most cited 2025 guides on probabilistic vs deterministic evaluation. **🟢 Beginner**
-- [Cekura  Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview)  Predefined metrics, instruction-following checks, and simulation framework. **🟢 Beginner**
-- [Cekura  Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura)  Practical 2025 guide on multi-turn simulation and edge-case generation. **🟡 Intermediate**
-- [Hamming AI](https://hamming.ai/)  Production-focused QA platform with simulation, load testing, and 50+ metrics. **🟡 Intermediate**
-- [Hamming  Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide)  Reference of latency percentiles, WER, MOS-style quality, and task completion with formulas. **🟡 Intermediate**
-- [LiveKit  Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)  Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize. **🟡 Intermediate**
-- [Twilio  How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)  Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency. **🟢 Beginner**
-- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)  Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation. **🟡 Intermediate**
+- [Coval: Voice AI Testing Platform](https://www.coval.ai/): Defines the core voice-agent metrics: TTFB, WER, resolution rate, simulated accents, and interruptions. **🟢 Beginner**
+- [Coval: How to Evaluate Voice Agents (Practical Guide)](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance): One of the most cited 2025 guides on probabilistic vs deterministic evaluation. **🟢 Beginner**
+- [Cekura: Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview): Predefined metrics, instruction-following checks, and simulation framework. **🟢 Beginner**
+- [Cekura: Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura): Practical 2025 guide on multi-turn simulation and edge-case generation. **🟡 Intermediate**
+- [Hamming AI](https://hamming.ai/): Production-focused QA platform with simulation, load testing, and 50+ metrics. **🟡 Intermediate**
+- [Hamming: Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide): Reference of latency percentiles, WER, MOS-style quality, and task completion with formulas. **🟡 Intermediate**
+- [LiveKit: Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency): Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize. **🟡 Intermediate**
+- [Twilio: How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents): Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency. **🟢 Beginner**
+- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk): Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation. **🟡 Intermediate**
 
 ## 15. Production, deployment, and scaling
 
 Real production voice infrastructure is **the hardest unsolved problem in this space**. Read these before quoting anyone a per-minute price.
 
-- [LiveKit  Deploy and scale agents on LiveKit Cloud](https://blog.livekit.io/deploy-and-scale-agents-on-livekit-cloud/)  Real-world write-up on stateful load balancing, autoscaling, and warm pools. **🟡 Intermediate**
-- [LiveKit  Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis)  Honest breakdown of what raw model APIs don't give you. **🟡 Intermediate**
-- [Latent Space  OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api)  Field-tested guide from Pipecat's creator on Realtime API production realities. **🟡 Intermediate**
-- [TWIML  Building Voice AI Agents That Don't Suck (Kwindla Kramer)](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck)  One-hour discussion on real production architecture and turn-taking. **🟡 Intermediate**
-- [AWS  Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/)  Full architecture walkthrough including latency optimization and Nova Sonic. **🟡 Intermediate**
-- [Deepgram  STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025)  Vendor-by-vendor per-minute economics  required reading before signing any contract. **🟢 Beginner**
-- [Sierra  Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents)  Case-study on Sonos, SiriusXM, and OluKai voice deployments. **🟡 Intermediate**
-- [Sierra  Constellation of Models](https://sierra.ai/blog/constellation-of-models)  How a leading CX company composes 15+ models per agent. **🟡 Intermediate**
-- [LiveKit Agent Observability](https://livekit.com/products/agent-observability)  Built-in tracing, transcripts, and per-stage latency for LiveKit Cloud. **🟢 Beginner**
+- [LiveKit: Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/): Real-world write-up on stateful load balancing, autoscaling, and warm pools. **🟡 Intermediate**
+- [LiveKit: Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis): Honest breakdown of what raw model APIs don't give you. **🟡 Intermediate**
+- [Latent Space: OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api): Field-tested guide from Pipecat's creator on Realtime API production realities. **🟡 Intermediate**
+- [TWIML: Building Voice AI Agents That Don't Suck (Kwindla Kramer)](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck): One-hour discussion on real production architecture and turn-taking. **🟡 Intermediate**
+- [AWS: Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/): Full architecture walkthrough including latency optimization and Nova Sonic. **🟡 Intermediate**
+- [Deepgram: STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025): Vendor-by-vendor per-minute economics: required reading before signing any contract. **🟢 Beginner**
+- [Sierra: Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents): Case-study on Sonos, SiriusXM, and OluKai voice deployments. **🟡 Intermediate**
+- [Sierra: Constellation of Models](https://sierra.ai/blog/constellation-of-models): How a leading CX company composes 15+ models per agent. **🟡 Intermediate**
+- [LiveKit Agent Observability](https://livekit.com/products/agent-observability): Built-in tracing, transcripts, and per-stage latency for LiveKit Cloud. **🟢 Beginner**
 
 ## 16. Ethics, safety, and regulation
 
 If you're shipping a voice agent in 2026, **disclosure and consent are no longer optional**. The FCC and EU AI Act both have teeth.
 
-- [FCC  AI-Generated Voices in Robocalls Illegal (Feb 2024)](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)  The landmark TCPA ruling every U.S. voice-agent dev must read. **🟢 Beginner**
-- [EU AI Act  Article 50 (Transparency for Deepfakes & AI Interactions)](https://artificialintelligenceact.eu/article/50/)  Authoritative text of EU disclosure rules; takes effect August 2026. **🟡 Intermediate**
-- [European Commission  Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content)  Official EU implementation guidance on watermarking and labelling. **🟡 Intermediate**
-- [FTC  Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning)  Plain-English summary of the Voice Cloning Challenge winners and Impersonation Rule. **🟢 Beginner**
-- [FTC  Final Impersonation Rule (Feb 2024)](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals)  Direct source on U.S. impersonation-fraud rules covering AI deepfakes. **🟢 Beginner**
-- [Pindrop  2025 Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/)  Industry report documenting a 1,300% rise in deepfake fraud attempts. **🟢 Beginner**
-- [Voice Cloning Ethics (CAMB.AI)](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use)  Practical overview of consent frameworks, ELVIS Act, and EU AI Act. **🟢 Beginner**
-- [NCLC  Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025)  Consumer-protection lens on what's actually being enforced. **🟡 Intermediate**
+- [FCC: AI-Generated Voices in Robocalls Illegal (Feb 2024)](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal): The landmark TCPA ruling every U.S. voice-agent dev must read. **🟢 Beginner**
+- [EU AI Act: Article 50 (Transparency for Deepfakes & AI Interactions)](https://artificialintelligenceact.eu/article/50/): Authoritative text of EU disclosure rules; takes effect August 2026. **🟡 Intermediate**
+- [European Commission: Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content): Official EU implementation guidance on watermarking and labelling. **🟡 Intermediate**
+- [FTC: Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning): Plain-English summary of the Voice Cloning Challenge winners and Impersonation Rule. **🟢 Beginner**
+- [FTC: Proposed Rule on AI Impersonation of Individuals (Feb 2024)](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals): Direct source on U.S. impersonation-fraud rules covering AI deepfakes. **🟢 Beginner**
+- [Pindrop: 2025 Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/): Industry report documenting a 1,300% rise in deepfake fraud attempts. **🟢 Beginner**
+- [Voice Cloning Ethics (CAMB.AI)](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use): Practical overview of consent frameworks, ELVIS Act, and EU AI Act. **🟢 Beginner**
+- [NCLC: Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025): Consumer-protection lens on what's actually being enforced. **🟡 Intermediate**
 
 ## 17. Blogs and newsletters
 
-Subscribe to two or three to stay current  the field moves quickly.
+Subscribe to two or three to stay current: the field moves quickly.
 
-- [LiveKit Blog](https://blog.livekit.io/)  Engineering deep-dives on WebRTC, agents framework releases, and production patterns.
-- [Deepgram Learn](https://deepgram.com/learn)  Tutorials on STT/TTS, voice agent design, evals, and pipeline architecture.
-- [Cartesia Blog](https://cartesia.ai/blog)  State-space TTS models, Sonic releases, and yearly "State of Voice AI" reports.
-- [ElevenLabs Blog](https://elevenlabs.io/blog)  Product and research announcements with implementation notes.
-- [Daily.co Blog (Pipecat)](https://www.daily.co/blog/)  Posts from Pipecat's maintainers covering scaling and feature releases.
-- [Voice AI & Voice Agents  Illustrated Primer](https://voiceaiandvoiceagents.com/)  Free, regularly-updated long-form primer.
-- [Latent Space (swyx & Alessio)](https://www.latent.space/)  AI Engineer newsletter and podcast with frequent voice-AI episodes.
-- [Voice AI Newsletter (Krisp)](https://voice-ai-newsletter.krisp.ai/)  "Future of Voice AI" interview series with founders; published weekly in 2025.
-- [Voice AI Weekly (Vapi)](https://vapivoice.substack.com/)  Weekly Substack rounding up news, products, and tools.
-- [Voicebot.ai (Synthedia)](https://voicebot.ai/)  Long-running daily news and paid newsletter on industry trends.
+- [LiveKit Blog](https://livekit.com/blog/): Engineering deep-dives on WebRTC, agents framework releases, and production patterns.
+- [Deepgram Learn](https://deepgram.com/learn): Tutorials on STT/TTS, voice agent design, evals, and pipeline architecture.
+- [Cartesia Blog](https://cartesia.ai/blog): State-space TTS models, Sonic releases, and yearly "State of Voice AI" reports.
+- [ElevenLabs Blog](https://elevenlabs.io/blog): Product and research announcements with implementation notes.
+- [Daily.co Blog (Pipecat)](https://www.daily.co/blog/): Posts from Pipecat's maintainers covering scaling and feature releases.
+- [Voice AI & Voice Agents: An Illustrated Primer](https://voiceaiandvoiceagents.com/): Free, regularly-updated long-form primer.
+- [Latent Space (swyx & Alessio)](https://www.latent.space/): AI Engineer newsletter and podcast with frequent voice-AI episodes.
+- [Voice AI Newsletter (Krisp)](https://voice-ai-newsletter.krisp.ai/): "Future of Voice AI" interview series with founders; published weekly in 2025.
+- [Voice AI Weekly (Vapi)](https://vapivoice.substack.com/): Weekly Substack rounding up news, products, and tools.
+- [Voicebot.ai (Synthedia)](https://voicebot.ai/): Long-running daily news and paid newsletter on industry trends.
 
 ## 18. Podcasts
 
-- [The Voicebot Podcast (Bret Kinsella)](https://voicebot.ai/voicebot-podcasts/)  Longest-running serious voice-tech podcast; weekly founder interviews.
-- [Latent Space  The AI Engineer Podcast](https://www.latent.space/podcast)  Top US tech podcast; regularly covers Realtime API, Pipecat, Voxtral, Gemini Live.
-- [The Future of Voice AI (Krisp)](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184)  Weekly founder interviews focused on enterprise voice AI architecture.
-- [TWIML AI Podcast  voice episodes](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464)  Strong technical interviews; the Kwin Kramer episode is a great starting point.
-- [This Week In Voice (Project Voice)](https://thisweekinvoice.substack.com/)  News-roundtable format covering conversational AI.
+- [The Voicebot Podcast (Bret Kinsella)](https://voicebot.ai/voicebot-podcasts/): Longest-running serious voice-tech podcast; weekly founder interviews.
+- [Latent Space: The AI Engineer Podcast](https://www.latent.space/podcast): Top US tech podcast; regularly covers Realtime API, Pipecat, Voxtral, Gemini Live.
+- [The Future of Voice AI (Krisp)](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184): Weekly founder interviews focused on enterprise voice AI architecture.
+- [TWIML AI Podcast: voice episodes](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464): Strong technical interviews; the Kwin Kramer episode is a great starting point.
+- [This Week In Voice (Project Voice)](https://thisweekinvoice.substack.com/): News-roundtable format covering conversational AI.
 
 ## 19. Communities
 
-- [LiveKit Community Slack](https://livekit.io/join-slack)  Direct access to maintainers and other agent builders.
-- [Pipecat Discord](https://www.pipecat.ai/)  Active community with weekly office hours; invite link from the homepage.
-- [HuggingFace Discord  #ml-for-audio-and-speech](https://hf.co/join/discord)  200k-member server with strong audio/speech channels.
-- [Vapi Discord](https://vapi.ai/)  Builder community for Vapi voice agents; invite from the homepage.
-- [Retell AI Discord](https://www.retellai.com/)  Discord for Retell developers building phone-call voice agents.
-- [ElevenLabs Discord](https://discord.gg/elevenlabs)  Large TTS, voice cloning, and Conversational AI community with daily help threads.
-- [Deepgram Discord](https://deepgram.com/)  STT/TTS/Voice Agent API support and build-with-us threads.
-- [Reddit  r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/)  Active threads on local Whisper/Parakeet, on-device TTS, and end-to-end voice stacks.
-- [Reddit  r/AI_Agents](https://www.reddit.com/r/AI_Agents/)  General AI-agent community where voice topics surface frequently.
+- [LiveKit Community Slack](https://livekit.io/join-slack): Direct access to maintainers and other agent builders.
+- [Pipecat Discord](https://www.pipecat.ai/): Active community with weekly office hours; invite link from the homepage.
+- [HuggingFace Discord: #ml-for-audio-and-speech](https://hf.co/join/discord): 200k-member server with strong audio/speech channels.
+- [Vapi Discord](https://vapi.ai/): Builder community for Vapi voice agents; invite from the homepage.
+- [Retell AI Discord](https://www.retellai.com/): Discord for Retell developers building phone-call voice agents.
+- [ElevenLabs Discord](https://discord.gg/elevenlabs): Large TTS, voice cloning, and Conversational AI community with daily help threads.
+- [Deepgram Discord](https://deepgram.com/): STT/TTS/Voice Agent API support and build-with-us threads.
+- [Reddit: r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/): Active threads on local Whisper/Parakeet, on-device TTS, and end-to-end voice stacks.
+- [Reddit: r/AI_Agents](https://www.reddit.com/r/AI_Agents/): General AI-agent community where voice topics surface frequently.
 
 ## 20. Conferences and events
 
-- [AI Engineer World's Fair](https://www.ai.engineer/worldsfair)  Biggest AI-engineering conference; the Voice track has hosted major launches from ElevenLabs, Vapi, LiveKit, Pipecat, and Cartesia. **🟢 Beginner**
-- [AI Engineer YouTube channel](https://www.youtube.com/@aiDotEngineer)  All World's Fair and Summit talks are posted free; the best library of recent voice-AI talks. **🟢 Beginner**
-- [AI Engineer Summit Online  Voice playlist](https://www.youtube.com/playlist?list=PLcfpQ4tk2k0VetQVGT1EqTbcr-qcgbfFs)  Curated playlist including voice-track sessions from leading labs. **🟢 Beginner**
-- [AIEWF 2025 Recap (Latent Space)](https://www.latent.space/p/aiewf-2025-keynotes)  Written deep-dive into 2025's voice-track talks and major launches. **🟢 Beginner**
-- [VOICE & AI (Modev)](https://www.voicesummit.ai/)  Long-running voice technology conference with broader CX and voicebot focus. **🟢 Beginner**
-- [Project Voice](https://www.projectvoice.ai/annual-conference)  Main U.S. event for conversational AI across voice, text, and chat. **🟢 Beginner**
-- [Interspeech](https://www.interspeech2025.org/)  Top academic speech-science conference; intimidating but worth knowing  most landmark papers debut here. **🔴 Advanced**
+- [AI Engineer World's Fair](https://www.ai.engineer/worldsfair): Biggest AI-engineering conference; the Voice track has hosted major launches from ElevenLabs, Vapi, LiveKit, Pipecat, and Cartesia. **🟢 Beginner**
+- [AI Engineer YouTube channel](https://www.youtube.com/@aiDotEngineer): All World's Fair and Summit talks are posted free; the best library of recent voice-AI talks. **🟢 Beginner**
+- [AI Engineer Summit Online: Voice playlist](https://www.youtube.com/playlist?list=PLcfpQ4tk2k0VetQVGT1EqTbcr-qcgbfFs): Curated playlist including voice-track sessions from leading labs. **🟢 Beginner**
+- [AIEWF 2025 Recap (Latent Space)](https://www.latent.space/p/aiewf-2025-keynotes): Written deep-dive into 2025's voice-track talks and major launches. **🟢 Beginner**
+- [VOICE & AI (Modev)](https://www.voicesummit.ai/): Long-running voice technology conference with broader CX and voicebot focus. **🟢 Beginner**
+- [Project Voice](https://www.projectvoice.ai/annual-conference): Main U.S. event for conversational AI across voice, text, and chat. **🟢 Beginner**
+- [Interspeech](https://www.interspeech2025.org/): Top academic speech-science conference; intimidating but worth knowing: most landmark papers debut here. **🔴 Advanced**
 
 ## 21. Hackathons and competitions
 
-- [ElevenLabs Worldwide Hackathon](https://hackathon.elevenlabs.io/)  Flagship global hackathon for conversational agents; 30+ cities and a $200K+ prize pool. **🟢 Beginner**
-- [ElevenHacks (weekly sprints)](https://hacks.elevenlabs.io/)  Weekly themed challenges with credits and prizes; low-pressure way to ship one project per week. **🟢 Beginner**
-- [AI Engineer World's Fair Hackathon](https://www.ai.engineer/worldsfair)  Co-located with the conference; $10K prizes judged by 3,000+ AI engineers, with a strong voice track. **🟡 Intermediate**
-- [lablab.ai AI Hackathons](https://lablab.ai/event)  Continuous calendar of short online hackathons frequently sponsored by voice-AI vendors. **🟢 Beginner**
-- [Devpost  Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai)  Centralized search for active voice-AI hackathons; the best way to find what's open right now. **🟢 Beginner**
+- [ElevenLabs Worldwide Hackathon](https://hackathon.elevenlabs.io/): Flagship global hackathon for conversational agents; 30+ cities and a $200K+ prize pool. **🟢 Beginner**
+- [ElevenHacks (weekly sprints)](https://hacks.elevenlabs.io/): Weekly themed challenges with credits and prizes; low-pressure way to ship one project per week. **🟢 Beginner**
+- [AI Engineer World's Fair Hackathon](https://www.ai.engineer/worldsfair): Co-located with the conference; $10K prizes judged by 3,000+ AI engineers, with a strong voice track. **🟡 Intermediate**
+- [lablab.ai AI Hackathons](https://lablab.ai/event): Continuous calendar of short online hackathons frequently sponsored by voice-AI vendors. **🟢 Beginner**
+- [Devpost: Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai): Centralized search for active voice-AI hackathons; the best way to find what's open right now. **🟢 Beginner**
 
 ---
 
 ## Suggested learning path
 
-1. **Week 1  Foundations:** Read the LiveKit pipeline post and Voice AI Illustrated Primer (sections 1, 8).
-2. **Week 2  First agent:** Finish the LiveKit *or* Pipecat quickstart end-to-end (sections 2, 10).
-3. **Week 3  Components:** Swap STT, TTS, and LLM providers; benchmark latency (sections 3, 4, 5).
-4. **Week 4  Turn-taking, audio cleanup & telephony:** Add Silero VAD, a turn detector, and a speech-enhancement pass; connect a SIP trunk (sections 6, 7, 9).
-5. **Week 5  Production:** Add evaluation, observability, and read the FCC/EU AI Act material (sections 14, 15, 16).
-6. **Ongoing:** Subscribe to two newsletters and join voice ai community in [linkedin](https://www.linkedin.com/groups/14269127/) (sections 17, 18, 19).
+1. **Week 1: Foundations:** Read the LiveKit pipeline post and Voice AI Illustrated Primer (sections 1, 8).
+2. **Week 2: First agent:** Finish the LiveKit *or* Pipecat quickstart end-to-end (sections 2, 10).
+3. **Week 3: Components:** Swap STT, TTS, and LLM providers; benchmark latency (sections 3, 4, 5).
+4. **Week 4: Turn-taking, audio cleanup & telephony:** Add Silero VAD, a turn detector, and a speech-enhancement pass; connect a SIP trunk (sections 6, 7, 9).
+5. **Week 5: Production:** Add evaluation, observability, and read the FCC/EU AI Act material (sections 14, 15, 16).
+6. **Ongoing:** Subscribe to two newsletters and join the Voice AI community on [LinkedIn group](https://www.linkedin.com/groups/14269127/) (sections 17, 18, 19).
 
 ## Contributing
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,12 +1,12 @@
 ![Banner Image](banner.png)
 
-> [English version](./README.md) [中文版本](./README_zh.md)
+> [English version](./README.md) | 中文版本
 
 > 一条精心整理的、面向开发者的学习路径：从第一次调用 STT，到把生产级电话语音智能体规模化上线。
 
 语音智能体在不到三年里已从研究演示走进真实产品。**现代技术栈正收敛为一种清晰范式**：实时传输层（WebRTC 或电话网）、语音转文字 → 大语言模型 → 文字转语音的流式流水线，以及决定语音智能体何时开口的话轮模型。本清单的结构刻意贴近这一学习顺序——先打基础，再选框架，然后深入各组件与上线相关议题。
 
-资源标注为 **🟢 入门**、**🟡 进阶** 或 **🔴 高阶**。优先收录免费官方文档与厂商中立指南；**条目若存在商业背景会明确标注**。
+学习类资源标注为 **🟢 入门**、**🟡 进阶** 或 **🔴 高阶**（第 17-19 节的博客、播客与社区有意不作标注）。优先收录免费官方文档与厂商中立指南；**条目若存在商业背景会明确标注**。
 
 ---
 
@@ -24,7 +24,7 @@
 
 ## 📘 配套图书：《Voice Agents Handbook》
 
-如果你想以更紧凑、有立场、面向生产的形式获得这些内容，可以阅读我撰写的 **[Voice Agents Handbook](https://handbook.mahimai.ca)**：基于 LiveKit 构建生产级语音 AI，附录涵盖技术栈选型与 LiveKit 生态中智能体之外的内容。2026 年 6 月 1 日在 Kindle 上架。
+如果你想以更紧凑、有立场、面向生产的形式获得这些内容，可以阅读我撰写的 **[Voice Agents Handbook](https://handbook.mahimai.ca)**：基于 LiveKit 构建生产级语音 AI，附录涵盖技术栈选型与 LiveKit 生态中智能体之外的内容。现已在 Kindle 上架（同时提供纸质版）。
 
 你正在读的 README 收录了本领域最好的免费资源，本书则是穿越这些资源的一条精选路径，融入了我在为技工、律师与移民顾问交付语音智能体过程中沉淀的模式。
 
@@ -62,116 +62,116 @@
 
 从这里开始。下列资源帮你建立**语音智能体流水线的心智模型**，以及职业生涯里会持续打交道的**延迟预算**。
 
-- [语音智能体图解入门（Voice AI & Voice Agents）](https://voiceaiandvoiceagents.com/) — Kwindla Hultman Kramer 的免费、持续更新的长文入门书，可视为本领域的默认教材。**🟢 入门**
-- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained（LiveKit）](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained) — 图解流式模式、话轮检测及延迟主要落在哪些环节。**🟢 入门**
-- [Everything You Need to Know About Voice AI Agents（Deepgram）](https://deepgram.com/learn/everything-about-voice-ai-agents) — 端到端入门，涵盖特征提取、ASR、LLM 推理与合成。**🟢 入门**
-- [AI Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/voice-agent/) — 权威的「什么是语音智能体」参考，涵盖**流水线式与多模态**两条路线，以及语音智能体状态。**🟢 入门**
-- [Core Latency in AI Voice Agents（Twilio）](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents) — 图解话末检测、静音阈值与智能端点检测（endpointing）。**🟢 入门**
-- [Advice on Building Voice AI in June 2025（Daily.co）](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/) — Pipecat 创始团队给出的 P50/P95 延迟预算实用建议。**🟡 进阶**
-- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents（AssemblyAI）](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent) — 端点检测是最容易被低估的问题；本文是讲得最透的深度文之一。**🟡 进阶**
+- [语音智能体图解入门（Voice AI & Voice Agents）](https://voiceaiandvoiceagents.com/)：Kwindla Hultman Kramer 的免费、持续更新的长文入门书，可视为本领域的默认教材。**🟢 入门**
+- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained（LiveKit）](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained)：图解流式模式、话轮检测及延迟主要落在哪些环节。**🟢 入门**
+- [Everything You Need to Know About Voice AI Agents（Deepgram）](https://deepgram.com/learn/everything-about-voice-ai-agents)：端到端入门，涵盖特征提取、ASR、LLM 推理与合成。**🟢 入门**
+- [AI Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/voice-agent/)：权威的「什么是语音智能体」参考，涵盖**流水线式与多模态**两条路线，以及语音智能体状态。**🟢 入门**
+- [Core Latency in AI Voice Agents（Twilio）](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents)：图解话末检测、静音阈值与智能端点检测（endpointing）。**🟢 入门**
+- [Advice on Building Voice AI in June 2025（Daily.co）](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/)：Pipecat 创始团队给出的 P50/P95 延迟预算实用建议。**🟡 进阶**
+- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents（AssemblyAI）](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent)：端点检测是最容易被低估的问题；本文是讲得最透的深度文之一。**🟡 进阶**
 
 ## 2. 框架与编排平台
 
 下列框架都能把 STT、LLM 与 TTS 串起来。**若走开源生产路线，LiveKit Agents 与 Pipecat 通常是最稳妥的两款框架**；若偏好托管控制台，Vapi、Retell、Bland 在「从 0 到第一次通话」上非常省时。
 
 ### 开源框架
-- [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/) — 约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。**🟢 入门**
-- [Pipecat：Quickstart](https://docs.pipecat.ai/getting-started/quickstart) — 脚手架搭好 Deepgram + OpenAI + Cartesia 流水线，5 分钟内可在浏览器里对话。**🟢 入门**
-- [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox) — 开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。**🔴 高阶**
+- [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/)：约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。**🟢 入门**
+- [Pipecat：Quickstart](https://docs.pipecat.ai/getting-started/quickstart)：脚手架搭好 Deepgram + OpenAI + Cartesia 流水线，5 分钟内可在浏览器里对话。**🟢 入门**
+- [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox)：开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。**🔴 高阶**
 
 ### 托管平台
-- [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction) — 以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。**🟢 入门**
-- [Retell AI：Introduction & Quickstart](https://docs.retellai.com/general/introduction) — 电话语音智能体平台，注册送 $10 额度。**🟢 入门**
-- [Bland AI：Send Your First Phone Call](https://docs.bland.ai/tutorials/send-first-call) — 极简 API 教程，打出第一通 AI 电话。**🟢 入门**
-- [ElevenLabs Conversational AI：Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart) — 约 5 分钟内在任意网站嵌入语音智能体组件。**🟢 入门**
+- [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction)：以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。**🟢 入门**
+- [Retell AI：Introduction & Quickstart](https://docs.retellai.com/general/introduction)：电话语音智能体平台，注册送 $10 额度。**🟢 入门**
+- [Bland AI：Send Your First Phone Call](https://docs.bland.ai/tutorials/send-first-call)：极简 API 教程，打出第一通 AI 电话。**🟢 入门**
+- [ElevenLabs Conversational AI：Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart)：约 5 分钟内在任意网站嵌入语音智能体组件。**🟢 入门**
 
 ### 实时 / 语音到语音 API
-- [OpenAI Realtime API：指南](https://platform.openai.com/docs/guides/realtime) — `gpt-realtime` 通过 WebRTC、WebSocket 或 SIP 接入的官方说明。**🟡 进阶**
-- [Google Gemini Live API：概览](https://ai.google.dev/gemini-api/docs/live-api) — 低延迟双向语音 + 视觉，支持插话（barge-in）与工具调用。**🟡 进阶**
-- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay) — WebSocket 桥接，托管 STT/TTS，你专注 LLM 逻辑；可与任意 LLM 配合。**🟡 进阶**
+- [OpenAI Realtime API：指南](https://platform.openai.com/docs/guides/realtime)：`gpt-realtime` 通过 WebRTC、WebSocket 或 SIP 接入的官方说明。**🟡 进阶**
+- [Google Gemini Live API：概览](https://ai.google.dev/gemini-api/docs/live-api)：低延迟双向语音 + 视觉，支持插话（barge-in）与工具调用。**🟡 进阶**
+- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay)：WebSocket 桥接，托管 STT/TTS，你专注 LLM 逻辑；可与任意 LLM 配合。**🟡 进阶**
 
 ### 厂商中立对比
-- [Vapi vs Pipecat vs LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit) — 从架构视角对比流水线控制与传输选型。**🟡 进阶**
-- [11 Voice Agent Platforms Compared（Softcery）](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025) — 覆盖面广的市场地图与场景建议。**🟢 入门**
-- [Best Voice Agent Stack（Hamming AI）](https://hamming.ai/resources/best-voice-agent-stack) — 自研 vs 采购框架，含具体成本、延迟与上线周期数字。**🟡 进阶**
+- [Vapi vs Pipecat vs LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit)：从架构视角对比流水线控制与传输选型。**🟡 进阶**
+- [11 Voice Agent Platforms Compared（Softcery）](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025)：覆盖面广的市场地图与场景建议。**🟢 入门**
+- [Best Voice Agent Stack（Hamming AI）](https://hamming.ai/resources/best-voice-agent-stack)：自研 vs 采购框架，含具体成本、延迟与上线周期数字。**🟡 进阶**
 
 ## 3. 语音转文字（STT / ASR）
 
 **先选定一种流式 STT 并学深**，再四处比价。Deepgram、AssemblyAI 与 Whisper 衍生方案已覆盖多数场景。
 
 ### 商业 API
-- [Deepgram Nova-3：STT 基准](https://deepgram.com/learn/speech-to-text-benchmarks) — 在 WER、延迟与成本语境下介绍 Deepgram 产品。**🟢 入门**
-- [AssemblyAI Universal-Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling) — 流式 STT 教程，同时可作为 function calling 示例。**🟡 进阶**
-- [OpenAI Whisper / gpt-4o-transcribe API 文档](https://platform.openai.com/docs/guides/speech-to-text) — 若已用 OpenAI，这是最容易上手的云端 STT。**🟢 入门**
-- [Soniox 多语言基准](https://soniox.com/benchmarks) — 公开 WER，覆盖约 60 种语言。**🟢 入门**
-- [Cartesia Ink](https://docs.cartesia.ai/) — 流式 STT 搭配 Sonic TTS，单供应商低延迟栈。**🟢 入门**
+- [Deepgram Nova-3：STT 基准](https://deepgram.com/learn/speech-to-text-benchmarks)：在 WER、延迟与成本语境下介绍 Deepgram 产品。**🟢 入门**
+- [AssemblyAI Universal-Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling)：流式 STT 教程，同时可作为 function calling 示例。**🟡 进阶**
+- [OpenAI Whisper / gpt-4o-transcribe API 文档](https://platform.openai.com/docs/guides/speech-to-text)：若已用 OpenAI，这是最容易上手的云端 STT。**🟢 入门**
+- [Soniox 多语言基准](https://soniox.com/benchmarks)：公开 WER，覆盖约 60 种语言。**🟢 入门**
+- [Cartesia Ink](https://docs.cartesia.ai/)：流式 STT 搭配 Sonic TTS，单供应商低延迟栈。**🟢 入门**
 
 ### 开源
-- [openai/whisper](https://github.com/openai/whisper) — 原仓库与 DIY ASR 的事实起点。**🟢 入门**
-- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper) — 基于 CTranslate2 的实现，INT8 下可达约 4× 提速；自托管 Whisper 常用。**🟡 进阶**
-- [NVIDIA NeMo（Parakeet / Canary）](https://github.com/NVIDIA-NeMo/NeMo) — 榜单前列的开源 ASR 与流式推理方案。**🔴 高阶**
-- [Moonshine](https://github.com/moonshine-ai/moonshine) — 轻量端侧 ASR（约 190 MB），针对边缘设备实时流优化。**🟡 进阶**
+- [openai/whisper](https://github.com/openai/whisper)：原仓库与 DIY ASR 的事实起点。**🟢 入门**
+- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper)：基于 CTranslate2 的实现，INT8 下可达约 4× 提速；自托管 Whisper 常用。**🟡 进阶**
+- [NVIDIA NeMo（Parakeet / Canary）](https://github.com/NVIDIA-NeMo/NeMo)：榜单前列的开源 ASR 与流式推理方案。**🔴 高阶**
+- [Moonshine](https://github.com/moonshine-ai/moonshine)：轻量端侧 ASR（tiny 27M / base 61M 参数），针对边缘设备实时流优化。**🟡 进阶**
 
 ### 基准与讲解
-- [Open ASR Leaderboard（HuggingFace）](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard) — 社区榜单，11 个数据集；开源选型参考。**🟢 入门**
-- [Artificial Analysis：Speech-to-Text](https://artificialanalysis.ai/speech-to-text) — 独立榜单，按 WER、速度与成本排名 48+ 家 STT。**🟢 入门**
-- [Streaming vs Batch ASR（Arun Baby）](https://www.arunbaby.com/speech-tech/0001-streaming-asr/) — 面向工程师的 RNN-T 与 Conformer 流式架构说明。**🟡 进阶**
+- [Open ASR Leaderboard（HuggingFace）](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：社区榜单，11 个数据集；开源选型参考。**🟢 入门**
+- [Artificial Analysis：Speech-to-Text](https://artificialanalysis.ai/speech-to-text)：独立榜单，按 WER、速度与成本排名 48+ 家 STT。**🟢 入门**
+- [Streaming vs Batch ASR（Arun Baby）](https://www.arunbaby.com/speech-tech/0001-streaming-asr/)：面向工程师的 RNN-T 与 Conformer 流式架构说明。**🟡 进阶**
 
 ## 4. 文字转语音（TTS）
 
 **拖垮语音智能体的往往是延迟，而非单纯音质**——应优先选择真正的流式输出、首字节在 200 ms 以内的供应商。
 
 ### 商业 API
-- [ElevenLabs 文档](https://elevenlabs.io/docs) — 业界领先音质、声音克隆与 Conversational AI 同属一套 SDK。**🟢 入门**
-- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/get-started/quickstart) — 首字节低于 100 ms，面向语音智能体设计。**🟢 入门**
-- [Deepgram Aura](https://developers.deepgram.com/docs/tts-models) — 低延迟流式 TTS，与 Deepgram STT 衔接顺畅。**🟢 入门**
-- [OpenAI TTS（gpt-4o-mini-tts）](https://platform.openai.com/docs/guides/text-to-speech) — OpenAI 栈里最容易接入的 TTS。**🟢 入门**
-- [Artificial Analysis：TTS 榜单](https://artificialanalysis.ai/text-to-speech/models) — ELO、价格与速度对比，含 Rime、PlayHT、Hume、Inworld 等。**🟢 入门**
+- [ElevenLabs 文档](https://elevenlabs.io/docs)：业界领先音质、声音克隆与 Conversational AI 同属一套 SDK。**🟢 入门**
+- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/get-started/realtime-text-to-speech-quickstart)：首字节低于 100 ms，面向语音智能体设计。**🟢 入门**
+- [Deepgram Aura](https://developers.deepgram.com/docs/tts-models)：低延迟流式 TTS，与 Deepgram STT 衔接顺畅。**🟢 入门**
+- [OpenAI TTS（gpt-4o-mini-tts）](https://platform.openai.com/docs/guides/text-to-speech)：OpenAI 栈里最容易接入的 TTS。**🟢 入门**
+- [Artificial Analysis：TTS 榜单](https://artificialanalysis.ai/text-to-speech/models)：ELO、价格与速度对比，含 Rime、PlayHT、Hume、Inworld 等。**🟢 入门**
 
 ### 开源
-- [Coqui TTS（idiap fork）](https://github.com/idiap/coqui-ai-TTS) — Coqui-TTS / XTTS v2 的持续维护分支；实战最多的开源 TTS 工具包。**🟡 进阶**
-- [Piper（OHF-Voice/piper1-gpl）](https://github.com/OHF-Voice/piper1-gpl) — 面向树莓派等设备的快速本地神经 TTS，适合离线项目。**🟢 入门**
-- [Kokoro 82M](https://github.com/hexgrad/kokoro) — 体积小、Apache 许可，在社区 ELO 对战中表现突出；可跑 CPU。**🟢 入门**
-- [F5-TTS](https://github.com/SWivid/F5-TTS) — 扩散+Transformer TTS，零样本声音克隆质量高。**🟡 进阶**
-- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS) — 基于 Llama-3B 的带情感 TTS，流式时延约 200 ms，支持情感标签。**🟡 进阶**
-- [Sesame CSM](https://github.com/SesameAILabs/csm) — 对话向、上下文感知的多说话人 TTS，Llama 骨干 + Mimi 编解码。**🔴 高阶**
+- [Coqui TTS（idiap fork）](https://github.com/idiap/coqui-ai-TTS)：Coqui-TTS / XTTS v2 的持续维护分支；实战最多的开源 TTS 工具包。**🟡 进阶**
+- [Piper（OHF-Voice/piper1-gpl）](https://github.com/OHF-Voice/piper1-gpl)：面向树莓派等设备的快速本地神经 TTS，适合离线项目。**🟢 入门**
+- [Kokoro 82M](https://github.com/hexgrad/kokoro)：体积小、Apache 许可，在社区 ELO 对战中表现突出；可跑 CPU。**🟢 入门**
+- [F5-TTS](https://github.com/SWivid/F5-TTS)：扩散+Transformer TTS，零样本声音克隆质量高。**🟡 进阶**
+- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS)：基于 Llama-3B 的带情感 TTS，流式时延约 200 ms，支持情感标签。**🟡 进阶**
+- [Sesame CSM](https://github.com/SesameAILabs/csm)：对话向、上下文感知的多说话人 TTS，Llama 骨干 + Mimi 编解码。**🔴 高阶**
 
 ### 流式与伦理
-- [Streaming TTS for Low-Latency Agents（Picovoice）](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/) — 清晰区分单流、输出流式与双流 TTS。**🟡 进阶**
-- [Ethics of Voice Cloning & Deepfakes（Deepgram）](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes) — 厂商中立讨论滥用、监管与开发者责任。**🟢 入门**
+- [Streaming TTS for Low-Latency Agents（Picovoice）](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/)：清晰区分单流、输出流式与双流 TTS。**🟡 进阶**
+- [Ethics of Voice Cloning & Deepfakes（Deepgram）](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes)：厂商中立讨论滥用、监管与开发者责任。**🟢 入门**
 
 ## 5. 面向语音智能体与实时场景的 LLM
 
 用户感知的「是否聪明」很大程度上取决于 **LLM 能多快开始输出第一个 token**。首 token 时延（TTFT）低于约 300 ms 会显著改变对话体感。
 
 ### 低延迟推理
-- [Groq](https://groq.com/) — LPU 推理云，Llama 吞吐相对常规 GPU 可达约 10×。**🟢 入门**
-- [Cerebras Inference](https://www.cerebras.ai/inference) — 晶圆级芯片推理，Llama 类模型吞吐很高。**🟢 入门**
-- [SambaNova Cloud](https://cloud.sambanova.ai/) — 可重构数据流架构上的推理服务；低延迟下吞吐稳定。**🟢 入门**
+- [Groq](https://groq.com/)：LPU 推理云，Llama 吞吐相对常规 GPU 可达约 10×。**🟢 入门**
+- [Cerebras Inference](https://www.cerebras.ai/inference)：晶圆级芯片推理，Llama 类模型吞吐很高。**🟢 入门**
+- [SambaNova Cloud](https://cloud.sambanova.ai/)：可重构数据流架构上的推理服务；低延迟下吞吐稳定。**🟢 入门**
 
 ### 语音到语音模型
-- [OpenAI Realtime API 指南](https://platform.openai.com/docs/guides/realtime) — 旗舰级 S2S，传输为 WebRTC/WebSocket。**🟡 进阶**
-- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api) — 实时多模态语音/视频，支持插话与约 70 种语言。**🟡 进阶**
-- [Moshi（kyutai-labs）](https://github.com/kyutai-labs/moshi) — 开源全双工语音–文本基础模型，延迟约 200 ms；最值得优先钻研的开源 S2S 模型之一。**🔴 高阶**
+- [OpenAI Realtime API 指南](https://platform.openai.com/docs/guides/realtime)：旗舰级 S2S，传输为 WebRTC/WebSocket。**🟡 进阶**
+- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api)：实时多模态语音/视频，支持插话与约 70 种语言。**🟡 进阶**
+- [Moshi（kyutai-labs）](https://github.com/kyutai-labs/moshi)：开源全双工语音–文本基础模型，延迟约 200 ms；最值得优先钻研的开源 S2S 模型之一。**🔴 高阶**
 
 ### 面向语音智能体的提示与工具
-- [OpenAI Voice Agents 指南](https://platform.openai.com/docs/guides/voice-agents) — 对比链式 vs S2S 架构，含提示与工具最佳实践。**🟢 入门**
-- [ElevenLabs Voice Agent Prompting 指南](https://elevenlabs.io/docs/conversational-ai/best-practices/prompting-guide) — 面向语音智能体的生产级提示结构，经验可泛化。**🟡 进阶**
-- [Voice AI Prompt Engineering Guide（VoiceInfra）](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide) — 解释为何面向语音智能体的提示通常要比聊天场景短约 60–70%，附模板。**🟢 入门**
-- [Function Calling for Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/voice-agent/function-calling/) — 在语音智能体中定义工具与 RPC 的简明指南。**🟡 进阶**
+- [OpenAI Voice Agents 指南](https://platform.openai.com/docs/guides/voice-agents)：对比链式 vs S2S 架构，含提示与工具最佳实践。**🟢 入门**
+- [ElevenLabs Voice Agent Prompting 指南](https://elevenlabs.io/docs/agents-platform/best-practices/prompting-guide)：面向语音智能体的生产级提示结构，经验可泛化。**🟡 进阶**
+- [Voice AI Prompt Engineering Guide（VoiceInfra）](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide)：解释为何面向语音智能体的提示通常要比聊天场景短约 60–70%，附模板。**🟢 入门**
+- [Function Calling for Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/voice-agent/function-calling/)：在语音智能体中定义工具与 RPC 的简明指南。**🟡 进阶**
 
 ## 6. 语音活动检测与话轮转换
 
 **仅靠传统 VAD 已不够**——现代方案往往把**声学 VAD**与预测话末的**小型语义模型**（结合用词与韵律）结合起来。
 
-- [Silero VAD](https://github.com/snakers4/silero-vad) — MIT 许可的预训练 VAD；CPU 上每个音频处理块可低至 1 ms 以内。LiveKit 与 Pipecat 中的事实标准。**🟢 入门**
-- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad) — 经典 Google WebRTC VAD 的 Python 绑定；轻量基线。**🟢 入门**
-- [LiveKit Turn Detector 博文](https://blog.livekit.io/using-a-transformer-to-improve-end-of-turn-detection) — 基于 SmolLM 的话末（EOU）模型如何用语义补足 VAD。**🟡 进阶**
-- [LiveKit turn-detector 模型（HuggingFace）](https://huggingface.co/livekit/turn-detector) — 开放权重多语言 EOU 模型，CPU 上以 ONNX 运行，内存占用不足 500 MB。**🟡 进阶**
-- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/) — 基于 Whisper-Tiny 的音频语义 VAD，CPU 上单次推理约 12 ms，BSD-2 许可。**🟡 进阶**
-- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn) — 模型代码、训练脚本与集成示例。**🟡 进阶**
-- [The Complete Guide to AI Turn-Taking（Tavus）](https://www.tavus.io/post/ai-turn-taking) — 易读总览：纯 VAD 为何在真实对话里失效。**🟢 入门**
-- [Tackling Turn Detection in Voice AI（Notch）](https://www.notch.cx/post/turn-detection-in-voice-ai) — 面向工程师的分步导读：VAD 概率、音量与 TTS 标记的组合。**🟡 进阶**
+- [Silero VAD](https://github.com/snakers4/silero-vad)：MIT 许可的预训练 VAD；CPU 上每个音频处理块可低至 1 ms 以内。LiveKit 与 Pipecat 中的事实标准。**🟢 入门**
+- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad)：经典 Google WebRTC VAD 的 Python 绑定；轻量基线。**🟢 入门**
+- [LiveKit Turn Detector 博文](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection)：基于小型 Transformer 的话末（EOU）模型如何用语义补足 VAD。**🟡 进阶**
+- [LiveKit turn-detector 模型（HuggingFace）](https://huggingface.co/livekit/turn-detector)：开放权重多语言 EOU 模型，CPU 上以 ONNX 运行，内存占用不足 500 MB。**🟡 进阶**
+- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/)：基于 Whisper-Tiny 的音频语义 VAD，CPU 上单次推理约 12 ms，BSD-2 许可。**🟡 进阶**
+- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn)：模型代码、训练脚本与集成示例。**🟡 进阶**
+- [The Complete Guide to AI Turn-Taking（Tavus）](https://www.tavus.io/blog/ai-turn-taking)：易读总览：纯 VAD 为何在真实对话里失效。**🟢 入门**
+- [Tackling Turn Detection in Voice AI（Notch）](https://www.notch.cx/post/turn-detection-in-voice-ai)：面向工程师的分步导读：VAD 概率、音量与 TTS 标记的组合。**🟡 进阶**
 - [ai-coustics VAD](https://developers.ai-coustics.com/)：与实时语音增强、降噪与人声分离打包在同一个音频预处理 SDK 中的 VAD；当你需要同一个组件同时给出清洁后的音频与话轮信号时尤其合适。**🟢 入门**
 
 ## 7. 音频增强与降噪
@@ -184,177 +184,177 @@
 
 对不走电话网的语音智能体，**WebRTC 是默认传输**。要做生产，**ICE、STUN、TURN 与 SFU 架构**不可不晓。
 
-- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API) — `RTCPeerConnection`、`getUserMedia` 与信令的权威参考。**🟢 入门**
-- [MDN：WebRTC 协议入门](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols) — ICE、STUN、TURN、SDP 的入门解释。**🟢 入门**
-- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview) — Google 维护的官方介绍，将 WebRTC 拆为采集与连通。**🟢 入门**
-- [GetStream：WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/) — 免费多模块教程，从网络基础到高阶主题。**🟢 入门**
-- [Why WebRTC Beats WebSockets for Voice AI（LiveKit）](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents) — 2025 年面向语音智能体构建者的传输对比，用语通俗。**🟡 进阶**
-- [Daily 文档：视频架构入门（P2P vs SFU）](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch) — P2P 与 SFU 最清晰的新手文之一。**🟢 入门**
-- [Agora：How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/) — WebRTC 与 WebSocket 对照，附信令示意图。**🟢 入门**
+- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)：`RTCPeerConnection`、`getUserMedia` 与信令的权威参考。**🟢 入门**
+- [MDN：WebRTC 协议入门](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols)：ICE、STUN、TURN、SDP 的入门解释。**🟢 入门**
+- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview)：Google 维护的官方介绍，将 WebRTC 拆为采集与连通。**🟢 入门**
+- [GetStream：WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/)：免费多模块教程，从网络基础到高阶主题。**🟢 入门**
+- [Why WebRTC Beats WebSockets for Voice AI（LiveKit）](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents)：2025 年面向语音智能体构建者的传输对比，用语通俗。**🟡 进阶**
+- [Daily 文档：视频架构入门（P2P vs SFU）](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch)：P2P 与 SFU 最清晰的新手文之一。**🟢 入门**
+- [Agora：How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/)：WebRTC 与 WebSocket 对照，附信令示意图。**🟢 入门**
 
 ## 9. 电话与 SIP
 
 电话网与互联网链路上的语音**环境、协议与约束各不相同**。理清 **SIP 中继**如何接入你所用的语音栈（例如基于 LiveKit 或 Pipecat 的部署），才能稳定连接 PSTN。
 
-- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice) — TwiML、Voice API 与 PSTN 一站式；常见起点。**🟢 入门**
-- [Twilio：Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python) — 分步教程，把 Twilio Media Streams 接到 LLM，对新手友好。**🟢 入门**
-- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart) — SIP 基础、SIP Domain 与软电话设置，入门最清楚。**🟢 入门**
-- [Telnyx Voice API](https://telnyx.com/products/voice-api) — 强有力的 Twilio 替代，含 WebSocket 媒体流与 AI Assistant 工具。**🟢 入门**
-- [Telnyx：How to Set Up a SIP Trunk](https://telnyx.com/resources/how-to-setup-sip-trunk) — SIP trunk 架构、编解码与认证的友好说明。**🟢 入门**
-- [Plivo Voice API 文档](https://www.plivo.com/docs/voice/) — XML 呼叫控制与面向语音智能体的音频流集成。**🟢 入门**
-- [SignalWire Voice 文档](https://developer.signalwire.com/voice/) — 基于 FreeSWITCH；SWML、类 TwiML API 与语音智能体 SDK（AI Agents SDK）。**🟡 进阶**
-- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/) — PSTN → 中继 → SIP 服务 → 语音智能体 的最佳示意图说明。**🟢 入门**
-- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/) — 将 Twilio/Telnyx/Plivo 中继接入 LiveKit 的实操。**🟡 进阶**
-- [Pipecat Telephony Overview](https://docs.pipecat.ai/guides/telephony/overview) — 基于 WebSocket 的电话与基于 SIP 的呼叫控制之差异。**🟡 进阶**
+- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice)：TwiML、Voice API 与 PSTN 一站式；常见起点。**🟢 入门**
+- [Twilio：Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python)：分步教程，把 Twilio Media Streams 接到 LLM，对新手友好。**🟢 入门**
+- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart)：SIP 基础、SIP Domain 与软电话设置，入门最清楚。**🟢 入门**
+- [Telnyx Voice API](https://telnyx.com/products/voice-api)：强有力的 Twilio 替代，含 WebSocket 媒体流与 AI Assistant 工具。**🟢 入门**
+- [Telnyx：How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk)：SIP trunk 架构、编解码与认证的友好说明。**🟢 入门**
+- [Plivo Voice API 文档](https://www.plivo.com/docs/voice/)：XML 呼叫控制与面向语音智能体的音频流集成。**🟢 入门**
+- [SignalWire Voice 文档](https://developer.signalwire.com/voice/)：基于 FreeSWITCH；SWML、类 TwiML API 与语音智能体 SDK（AI Agents SDK）。**🟡 进阶**
+- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/)：PSTN → 中继 → SIP 服务 → 语音智能体 的最佳示意图说明。**🟢 入门**
+- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/)：将 Twilio/Telnyx/Plivo 中继接入 LiveKit 的实操。**🟡 进阶**
+- [Pipecat Telephony Overview](https://docs.pipecat.ai/guides/telephony/overview)：基于 WebSocket 的电话与基于 SIP 的呼叫控制之差异。**🟡 进阶**
 
 ## 10. 教程与动手项目
 
 **选定一篇教程并做完再开下一篇**。语音智能体对「半成品流水线」极不宽容。
 
-- [LiveKit 语音智能体 Quickstart](https://docs.livekit.io/agents/start/voice-ai/) — 官方约 10 分钟 Python/Node 教程与模板。**🟢 入门**
-- [Build Your First AI Voice Agent in Python（LiveKit）](https://livekit.com/blog/build-your-first-ai-voice-agent-python) — 端到端 Python：流式、延迟与部署。**🟢 入门**
-- [Pipecat Quickstart](https://docs.pipecat.ai/getting-started/quickstart) — 约 10 分钟搭好 Deepgram + OpenAI + Cartesia 机器人。**🟢 入门**
-- [How to Build a Real-Time Voice Agent with Pipecat（AssemblyAI）](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat) — 偏生产：本地测试与 Pipecat Cloud 部署。**🟡 进阶**
-- [Deepgram：Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent) — 分步串联 Deepgram STT、GPT 与 Aura TTS。**🟢 入门**
-- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python) — 供应商无关，可接 OpenAI、Anthropic 或 DeepSeek。**🟡 进阶**
-- [freeCodeCamp：Build Advanced AI Agents（LiveKit, Exa, LangChain）](https://www.youtube.com/watch?v=B0TJC4lmzEM) — 免费三部分视频，端到端交互式语音智能体。**🟢 入门**
-- [freeCodeCamp：Private On-Device Voice Assistant](https://www.freecodecamp.org/news/private-voice-assistant-using-open-source-tools/) — 本地栈：Whisper、本地 LLM 与系统 TTS。**🟡 进阶**
+- [LiveKit 语音智能体 Quickstart](https://docs.livekit.io/agents/start/voice-ai/)：官方约 10 分钟 Python/Node 教程与模板。**🟢 入门**
+- [Build Your First AI Voice Agent in Python（LiveKit）](https://livekit.com/blog/build-your-first-ai-voice-agent-python)：端到端 Python：流式、延迟与部署。**🟢 入门**
+- [Pipecat Quickstart](https://docs.pipecat.ai/getting-started/quickstart)：约 10 分钟搭好 Deepgram + OpenAI + Cartesia 机器人。**🟢 入门**
+- [How to Build a Real-Time Voice Agent with Pipecat（AssemblyAI）](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat)：偏生产：本地测试与 Pipecat Cloud 部署。**🟡 进阶**
+- [Deepgram：Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent)：分步串联 Deepgram STT、GPT 与 Aura TTS。**🟢 入门**
+- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python)：供应商无关，可接 OpenAI、Anthropic 或 DeepSeek。**🟡 进阶**
+- [freeCodeCamp：Build Advanced AI Agents（LiveKit, Exa, LangChain）](https://www.youtube.com/watch?v=B0TJC4lmzEM)：免费三部分视频，端到端交互式语音智能体。**🟢 入门**
+- [freeCodeCamp：Private On-Device Voice Assistant](https://www.freecodecamp.org/news/private-voice-assistant-using-open-source-tools/)：本地栈：Whisper、本地 LLM 与系统 TTS。**🟡 进阶**
 
 ## 11. GitHub 入门仓库与 Awesome 列表
 
 与其从零写样板，不如直接 clone。
 
-- [livekit/agents](https://github.com/livekit/agents) — 旗舰级开源 Python/Node 生产语音智能体框架。**🟢 → 🔴**
-- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat) — 厂商中立，含 40+ STT/LLM/TTS 服务插件。**🟢 → 🔴**
-- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python) — 生产向 starter：Dockerfile、评测套件、话轮检测与核心插件。**🟢 入门**
-- [livekit-examples（组织）](https://github.com/livekit-examples) — LiveKit 官方 Python/React/Swift/Android 示例集合。**🟢 入门**
-- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples) — 按键说话、WebSocket、电话与多模态等示例。**🟢 → 🟡**
-- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples) — 可运行的 Next.js 与 Python 示例：TTS、STT 与实时语音智能体。**🟢 入门**
-- [vocodedev/vocode-core](https://github.com/vocodedev/vocode-core) — 开源模块化框架：支持电话、Zoom 或系统音频等场景的语音智能体。**🟡 进阶** *（维护活跃度低于 LiveKit/Pipecat）*
-- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents) — Pipecat 示例：在 M 系列 Mac 上全本地实现端到端语音延迟低于 800 ms。**🟡 进阶**
-- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers) — ASR、TTS、声音转换与语音–LLM 论文索引。**🟡 进阶**
-- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice) — 2025–2026 年持续更新的开源 TTS 与声音克隆模型列表。
-- [CorentinJ/Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning) — 经典 5 秒声音克隆项目，适合理解 TTS 基础。**🟡 进阶**
+- [livekit/agents](https://github.com/livekit/agents)：旗舰级开源 Python/Node 生产语音智能体框架。**🟢 → 🔴**
+- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat)：厂商中立，含 40+ STT/LLM/TTS 服务插件。**🟢 → 🔴**
+- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python)：生产向 starter：Dockerfile、评测套件、话轮检测与核心插件。**🟢 入门**
+- [livekit-examples（组织）](https://github.com/livekit-examples)：LiveKit 官方 Python/React/Swift/Android 示例集合。**🟢 入门**
+- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples)：按键说话、WebSocket、电话与多模态等示例。**🟢 → 🟡**
+- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples)：可运行的 Next.js 与 Python 示例：TTS、STT 与实时语音智能体。**🟢 入门**
+- [vocodedev/vocode-core](https://github.com/vocodedev/vocode-core)：开源模块化框架：支持电话、Zoom 或系统音频等场景的语音智能体。**🟡 进阶** *（维护活跃度低于 LiveKit/Pipecat）*
+- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)：Pipecat 示例：在 M 系列 Mac 上全本地实现端到端语音延迟低于 800 ms。**🟡 进阶**
+- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)：ASR、TTS、声音转换与语音–LLM 论文索引。**🟡 进阶**
+- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)：2025–2026 年持续更新的开源 TTS 与声音克隆模型列表。**🟢 入门**
+- [CorentinJ/Real-Time-Voice-Cloning](https://github.com/CorentinJ/Real-Time-Voice-Cloning)：经典 5 秒声音克隆项目，适合理解 TTS 基础。**🟡 进阶**
 
 ## 12. 数据集与基准
 
 你很少从零训练，但**模型在哪些数据上训练**决定了口音、语言与典型失效模式。
 
-- [LibriSpeech ASR Corpus](https://www.openslr.org/12) — 约 1,000 小时英语有声书；大量 ASR 论文以此为基准。**🟢 入门**
-- [Mozilla Common Voice](https://commonvoice.mozilla.org/) — 众包多语言（100+）；合法微调 ASR 的最易得途径之一。**🟢 入门**
-- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0) — 一行 `load_dataset()` 做实验。**🟢 入门**
-- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard) — 60+ 模型在 WER 与实时因子上的在线对比。**🟢 入门**
-- [Artificial Analysis：Speech](https://artificialanalysis.ai/speech-to-text) — 商业 STT/TTS 的独立基准。**🟢 入门**
-- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/) — 约 24 小时单说话人英语；Tacotron 2、VITS 等常用语料。**🟢 入门**
-- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443) — 约 110 位英语说话人，口音多样；多说话人 TTS 常用。**🟡 进阶**
-- [VoxCeleb（Oxford VGG）](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/) — 百万级「野外」语句，用于说话人识别与验证。**🟡 进阶**
+- [LibriSpeech ASR Corpus](https://www.openslr.org/12)：约 1,000 小时英语有声书；大量 ASR 论文以此为基准。**🟢 入门**
+- [Mozilla Common Voice](https://commonvoice.mozilla.org/)：众包多语言（100+）；合法微调 ASR 的最易得途径之一。**🟢 入门**
+- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0)：一行 `load_dataset()` 做实验。**🟢 入门**
+- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：60+ 模型在 WER 与实时因子上的在线对比。**🟢 入门**
+- [Artificial Analysis：Speech](https://artificialanalysis.ai/speech-to-text)：商业 STT/TTS 的独立基准。**🟢 入门**
+- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)：约 24 小时单说话人英语；Tacotron 2、VITS 等常用语料。**🟢 入门**
+- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443)：约 110 位英语说话人，口音多样；多说话人 TTS 常用。**🟡 进阶**
+- [VoxCeleb（Oxford VGG）](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/)：百万级「野外」语句，用于说话人识别与验证。**🟡 进阶**
 
 ## 13. 对初学者友好的研究论文
 
 这些是**你实际会用到的模型背后的里程碑论文**。建议先看 Whisper 与 Common Voice 两篇——文笔在机器学习论文里算格外友好。
 
-- [Whisper：Robust Speech Recognition via Large-Scale Weak Supervision（2022）](https://arxiv.org/abs/2212.04356) — 最流行的开源 ASR 背后；行文比一般 ML 论文清晰。**🟡 进阶**
-- [HuggingFace Whisper 微调博文（配套）](https://huggingface.co/blog/fine-tune-whisper) — 动手走一遍，用代码「感受」Whisper 论文。**🟢 入门**
-- [VITS：Conditional VAE with Adversarial Learning for End-to-End TTS（2021）](https://arxiv.org/abs/2106.06103) — 许多开源声音克隆器背后的单阶段 TTS。**🟡 进阶**
-- [Tacotron 2：Natural TTS Synthesis（2017）](https://arxiv.org/abs/1712.05884) — seq2seq + WaveNet 声码器的里程碑论文，让神经 TTS 听起来自然。**🟡 进阶**
-- [Conformer：Convolution-augmented Transformer for ASR（2020）](https://arxiv.org/abs/2005.08100) — NVIDIA Parakeet、Canary 及诸多榜单模型内部架构。**🟡 进阶**
-- [wav2vec 2.0：Self-Supervised Learning of Speech Representations（2020）](https://arxiv.org/abs/2006.11477) — 证明在无标注音频上预训练可大幅减少标注数据需求。**🟡 进阶**
-- [Common Voice：A Massively-Multilingual Speech Corpus（2020）](https://arxiv.org/abs/1912.06670) — 短文，易读，说明 Common Voice 如何构建与校验。**🟢 入门**
-- [Open ASR Leaderboard preprint（2025）](https://arxiv.org/abs/2510.06961) — 60+ 模型、11 个数据集的可复现基准；可作为当前开源 ASR 格局的全景参考。**🟡 进阶**
+- [Whisper：Robust Speech Recognition via Large-Scale Weak Supervision（2022）](https://arxiv.org/abs/2212.04356)：最流行的开源 ASR 背后；行文比一般 ML 论文清晰。**🟡 进阶**
+- [HuggingFace Whisper 微调博文（配套）](https://huggingface.co/blog/fine-tune-whisper)：动手走一遍，用代码「感受」Whisper 论文。**🟢 入门**
+- [VITS：Conditional VAE with Adversarial Learning for End-to-End TTS（2021）](https://arxiv.org/abs/2106.06103)：许多开源声音克隆器背后的单阶段 TTS。**🟡 进阶**
+- [Tacotron 2：Natural TTS Synthesis（2017）](https://arxiv.org/abs/1712.05884)：seq2seq + WaveNet 声码器的里程碑论文，让神经 TTS 听起来自然。**🟡 进阶**
+- [Conformer：Convolution-augmented Transformer for ASR（2020）](https://arxiv.org/abs/2005.08100)：NVIDIA Parakeet、Canary 及诸多榜单模型内部架构。**🟡 进阶**
+- [wav2vec 2.0：Self-Supervised Learning of Speech Representations（2020）](https://arxiv.org/abs/2006.11477)：证明在无标注音频上预训练可大幅减少标注数据需求。**🟡 进阶**
+- [Common Voice：A Massively-Multilingual Speech Corpus（2020）](https://arxiv.org/abs/1912.06670)：短文，易读，说明 Common Voice 如何构建与校验。**🟢 入门**
+- [Open ASR Leaderboard preprint（2025）](https://arxiv.org/abs/2510.06961)：60+ 模型、11 个数据集的可复现基准；可作为当前开源 ASR 格局的全景参考。**🟡 进阶**
 
 ## 14. 评测与测试
 
 不能度量就无法交付。**语音智能体评测本质上带有随机性**——同一转写在不同次运行中可能过也可能不过，因此**仿真与统计**比固定用例更重要。
 
-- [Coval：Voice AI Testing Platform](https://www.coval.dev/voice-ai-testing) — 定义核心指标：TTFB、WER、解决率、仿真口音与打断等。**🟢 入门**
-- [Coval：How to Evaluate Voice Agents（实用指南）](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance) — 2025 年常被引用的概率 vs 确定性评测指南。**🟢 入门**
-- [Cekura：Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview) — 预定义指标、指令遵循检查与仿真框架。**🟢 入门**
-- [Cekura：Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura) — 2025 实用文：多轮仿真与边界用例生成。**🟡 进阶**
-- [Hamming AI](https://hamming.ai/) — 生产向 QA：仿真、负载测试与 50+ 指标。**🟡 进阶**
-- [Hamming：Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide) — 延迟百分位数、WER、类 MOS 质量与任务完成率及计算公式。**🟡 进阶**
-- [LiveKit：Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency) — 每轮延迟（端到端、LLM TTFT、TTS TTFB）与优化切入点。**🟡 进阶**
-- [Twilio：How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents) — 2025 厂商中立文：主张业务结果指标优于单纯 WER/延迟。**🟢 入门**
-- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk) — 开源语音 AI 仿真 SDK，用于测试 AI 智能体；可生成合成对话用于评测。**🟡 进阶**
+- [Coval：Voice AI Testing Platform](https://www.coval.ai/)：定义核心指标：TTFB、WER、解决率、仿真口音与打断等。**🟢 入门**
+- [Coval：How to Evaluate Voice Agents（实用指南）](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance)：2025 年常被引用的概率 vs 确定性评测指南。**🟢 入门**
+- [Cekura：Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview)：预定义指标、指令遵循检查与仿真框架。**🟢 入门**
+- [Cekura：Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura)：2025 实用文：多轮仿真与边界用例生成。**🟡 进阶**
+- [Hamming AI](https://hamming.ai/)：生产向 QA：仿真、负载测试与 50+ 指标。**🟡 进阶**
+- [Hamming：Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide)：延迟百分位数、WER、类 MOS 质量与任务完成率及计算公式。**🟡 进阶**
+- [LiveKit：Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)：每轮延迟（端到端、LLM TTFT、TTS TTFB）与优化切入点。**🟡 进阶**
+- [Twilio：How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)：2025 厂商中立文：主张业务结果指标优于单纯 WER/延迟。**🟢 入门**
+- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)：开源语音 AI 仿真 SDK，用于测试 AI 智能体；可生成合成对话用于评测。**🟡 进阶**
 
 ## 15. 生产、部署与扩展
 
 语音智能体的生产级基础设施**仍是本领域最难且未完全标准化的问题**。在给人报「每分钟多少钱」之前，建议先读这些。
 
-- [LiveKit：Deploy and scale agents on LiveKit Cloud](https://blog.livekit.io/deploy-and-scale-agents-on-livekit-cloud/) — 有状态负载均衡、自动扩缩与预热池等实战经验。**🟡 进阶**
-- [LiveKit：Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis) — 坦率说明「裸调模型 API」缺什么。**🟡 进阶**
-- [Latent Space：OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api) — Pipecat 作者基于一线经验，揭开 Realtime API 在生产环境中的真实面貌。**🟡 进阶**
-- [TWIML：Building Voice AI Agents That Don't Suck（Kwindla Kramer）](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck) — 约一小时，谈真实生产架构与话轮。**🟡 进阶**
-- [AWS：Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/) — 完整架构含延迟优化与 Nova Sonic。**🟡 进阶**
-- [Deepgram：STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025) — 各家每分钟经济性——签合同前必读。**🟢 入门**
-- [Sierra：Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents) — Sonos、SiriusXM、OluKai 等语音智能体部署案例。**🟡 进阶**
-- [Sierra：Constellation of Models](https://sierra.ai/blog/constellation-of-models) — 领先客户体验（CX）公司如何在单个语音智能体里组合 15+ 模型。**🟡 进阶**
-- [LiveKit Agent Observability](https://livekit.com/products/agent-observability) — LiveKit Cloud 内置追踪、转写与各阶段延迟。**🟢 入门**
+- [LiveKit：Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/)：有状态负载均衡、自动扩缩与预热池等实战经验。**🟡 进阶**
+- [LiveKit：Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis)：坦率说明「裸调模型 API」缺什么。**🟡 进阶**
+- [Latent Space：OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api)：Pipecat 作者基于一线经验，揭开 Realtime API 在生产环境中的真实面貌。**🟡 进阶**
+- [TWIML：Building Voice AI Agents That Don't Suck（Kwindla Kramer）](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck)：约一小时，谈真实生产架构与话轮。**🟡 进阶**
+- [AWS：Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/)：完整架构含延迟优化与 Nova Sonic。**🟡 进阶**
+- [Deepgram：STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025)：各家每分钟经济性——签合同前必读。**🟢 入门**
+- [Sierra：Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents)：Sonos、SiriusXM、OluKai 等语音智能体部署案例。**🟡 进阶**
+- [Sierra：Constellation of Models](https://sierra.ai/blog/constellation-of-models)：领先客户体验（CX）公司如何在单个语音智能体里组合 15+ 模型。**🟡 进阶**
+- [LiveKit Agent Observability](https://livekit.com/products/agent-observability)：LiveKit Cloud 内置追踪、转写与各阶段延迟。**🟢 入门**
 
 ## 16. 伦理、安全与监管
 
 若在 2026 年对外发布语音智能体，**披露与同意已不再是可选项**。FCC 与欧盟《人工智能法》均有实质约束力。
 
-- [FCC：AI-Generated Voices in Robocalls Illegal（2024 年 2 月）](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal) — TCPA 里程碑裁定，美国语音智能体开发者应读。**🟢 入门**
-- [EU AI Act：Article 50（深度伪造与 AI 交互的透明度）](https://artificialintelligenceact.eu/article/50/) — 欧盟披露规则权威条文；2026 年 8 月生效。**🟡 进阶**
-- [European Commission：Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content) — 官方实施指引：水印与标注。**🟡 进阶**
-- [FTC：Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning) — 通俗总结 Voice Cloning Challenge 与冒充规则。**🟢 入门**
-- [FTC：Final Impersonation Rule（2024 年 2 月）](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals) — 美国冒充欺诈规则的一手来源，涵盖 AI 深度伪造。**🟢 入门**
-- [Pindrop：2025 Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/) — 行业报告：深度伪造诈骗尝试激增约 1,300%。**🟢 入门**
-- [Voice Cloning Ethics（CAMB.AI）](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use) — 同意框架、ELVIS 法案与欧盟 AI 法的实践概览。**🟢 入门**
-- [NCLC：Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025) — 消费者保护视角看实际执法重点。**🟡 进阶**
+- [FCC：AI-Generated Voices in Robocalls Illegal（2024 年 2 月）](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)：TCPA 里程碑裁定，美国语音智能体开发者应读。**🟢 入门**
+- [EU AI Act：Article 50（深度伪造与 AI 交互的透明度）](https://artificialintelligenceact.eu/article/50/)：欧盟披露规则权威条文；2026 年 8 月生效。**🟡 进阶**
+- [European Commission：Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content)：官方实施指引：水印与标注。**🟡 进阶**
+- [FTC：Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning)：通俗总结 Voice Cloning Challenge 与冒充规则。**🟢 入门**
+- [FTC：拟议的 AI 个人冒充规则（2024 年 2 月）](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals)：美国冒充欺诈规则的一手来源，涵盖 AI 深度伪造。**🟢 入门**
+- [Pindrop：2025 Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/)：行业报告：深度伪造诈骗尝试激增约 1,300%。**🟢 入门**
+- [Voice Cloning Ethics（CAMB.AI）](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use)：同意框架、ELVIS 法案与欧盟 AI 法的实践概览。**🟢 入门**
+- [NCLC：Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025)：消费者保护视角看实际执法重点。**🟡 进阶**
 
 ## 17. 博客与通讯
 
 订阅两三份即可跟上节奏——领域变化很快。
 
-- [LiveKit Blog](https://blog.livekit.io/) — WebRTC、语音智能体框架发布与生产实践方面的深度技术文章。
-- [Deepgram Learn](https://deepgram.com/learn) — STT/TTS、语音智能体设计、评测与流水线架构教程。
-- [Cartesia Blog](https://cartesia.ai/blog) — 状态空间 TTS、Sonic 发布与年度「State of Voice AI」。
-- [ElevenLabs Blog](https://elevenlabs.io/blog) — 产品与研发公告及实现笔记。
-- [Daily.co Blog（Pipecat）](https://www.daily.co/blog/) — Pipecat 维护者关于扩展与功能的文章。
-- [Voice AI & Voice Agents：图解入门](https://voiceaiandvoiceagents.com/) — 免费、持续更新的长文入门。
-- [Latent Space（swyx & Alessio）](https://www.latent.space/) — AI Engineer 通讯与播客，常有语音智能体专题。
-- [Voice AI Newsletter（Krisp）](https://voice-ai-newsletter.krisp.ai/) — 「Future of Voice AI」创始人访谈系列，2025 年周报。
-- [Voice AI Weekly（Vapi）](https://vapivoice.substack.com/) — 周报：新闻、产品与工具汇总。
-- [Voicebot.ai（Synthedia）](https://voicebot.ai/) — 长期运行的每日新闻与付费行业通讯。
+- [LiveKit Blog](https://livekit.com/blog/)：WebRTC、语音智能体框架发布与生产实践方面的深度技术文章。
+- [Deepgram Learn](https://deepgram.com/learn)：STT/TTS、语音智能体设计、评测与流水线架构教程。
+- [Cartesia Blog](https://cartesia.ai/blog)：状态空间 TTS、Sonic 发布与年度「State of Voice AI」。
+- [ElevenLabs Blog](https://elevenlabs.io/blog)：产品与研发公告及实现笔记。
+- [Daily.co Blog（Pipecat）](https://www.daily.co/blog/)：Pipecat 维护者关于扩展与功能的文章。
+- [Voice AI & Voice Agents：图解入门](https://voiceaiandvoiceagents.com/)：免费、持续更新的长文入门。
+- [Latent Space（swyx & Alessio）](https://www.latent.space/)：AI Engineer 通讯与播客，常有语音智能体专题。
+- [Voice AI Newsletter（Krisp）](https://voice-ai-newsletter.krisp.ai/)：「Future of Voice AI」创始人访谈系列，2025 年周报。
+- [Voice AI Weekly（Vapi）](https://vapivoice.substack.com/)：周报：新闻、产品与工具汇总。
+- [Voicebot.ai（Synthedia）](https://voicebot.ai/)：长期运行的每日新闻与付费行业通讯。
 
 ## 18. 播客
 
-- [The Voicebot Podcast（Bret Kinsella）](https://voicebot.ai/voicebot-podcasts/) — 运行最久、偏严肃的语音智能体技术播客；每周创始人访谈。
-- [Latent Space：The AI Engineer Podcast](https://www.latent.space/podcast) — 美国头部技术播客之一；常涉语音智能体相关技术，如 Realtime API、Pipecat、Voxtral、Gemini Live。
-- [The Future of Voice AI（Krisp）](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184) — 每周创始人访谈，侧重企业语音智能体架构。
-- [TWIML AI Podcast：语音相关单集](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464) — 技术访谈质量高；Kwindla Kramer 集适合入门。
-- [This Week In Voice（Project Voice）](https://thisweekinvoice.substack.com/) — 新闻圆桌，覆盖对话式 AI 与语音智能体。
+- [The Voicebot Podcast（Bret Kinsella）](https://voicebot.ai/voicebot-podcasts/)：运行最久、偏严肃的语音智能体技术播客；每周创始人访谈。
+- [Latent Space：The AI Engineer Podcast](https://www.latent.space/podcast)：美国头部技术播客之一；常涉语音智能体相关技术，如 Realtime API、Pipecat、Voxtral、Gemini Live。
+- [The Future of Voice AI（Krisp）](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184)：每周创始人访谈，侧重企业语音智能体架构。
+- [TWIML AI Podcast：语音相关单集](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464)：技术访谈质量高；Kwindla Kramer 集适合入门。
+- [This Week In Voice（Project Voice）](https://thisweekinvoice.substack.com/)：新闻圆桌，覆盖对话式 AI 与语音智能体。
 
 ## 19. 社区
 
-- [LiveKit Community Slack](https://livekit.io/join-slack) — 直接联系维护者与其他语音智能体开发者。
-- [Pipecat Discord](https://www.pipecat.ai/) — 活跃社区与每周线上答疑；邀请链接在主页。
-- [HuggingFace Discord：#ml-for-audio-and-speech](https://hf.co/join/discord) — 约 20 万成员的社区，音频与语音相关频道讨论活跃。
-- [Vapi Discord](https://vapi.ai/) — Vapi 语音智能体构建者社区；邀请在主页。
-- [Retell AI Discord](https://www.retellai.com/) — Retell 开发者，侧重电话语音智能体。
-- [ElevenLabs Discord](https://discord.gg/elevenlabs) — 大社区：TTS、声音克隆与 Conversational AI，每日互助帖。
-- [Deepgram Discord](https://deepgram.com/) — STT/TTS 与语音智能体 API 支持与共建讨论。
-- [Reddit：r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/) — 本地 Whisper/Parakeet、端侧 TTS 与端到端语音栈讨论活跃。
-- [Reddit：r/AI_Agents](https://www.reddit.com/r/AI_Agents/) — 通用 AI 智能体社区，语音智能体相关话题常见。
+- [LiveKit Community Slack](https://livekit.io/join-slack)：直接联系维护者与其他语音智能体开发者。
+- [Pipecat Discord](https://www.pipecat.ai/)：活跃社区与每周线上答疑；邀请链接在主页。
+- [HuggingFace Discord：#ml-for-audio-and-speech](https://hf.co/join/discord)：约 20 万成员的社区，音频与语音相关频道讨论活跃。
+- [Vapi Discord](https://vapi.ai/)：Vapi 语音智能体构建者社区；邀请在主页。
+- [Retell AI Discord](https://www.retellai.com/)：Retell 开发者，侧重电话语音智能体。
+- [ElevenLabs Discord](https://discord.gg/elevenlabs)：大社区：TTS、声音克隆与 Conversational AI，每日互助帖。
+- [Deepgram Discord](https://deepgram.com/)：STT/TTS 与语音智能体 API 支持与共建讨论。
+- [Reddit：r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/)：本地 Whisper/Parakeet、端侧 TTS 与端到端语音栈讨论活跃。
+- [Reddit：r/AI_Agents](https://www.reddit.com/r/AI_Agents/)：通用 AI 智能体社区，语音智能体相关话题常见。
 
 ## 20. 会议与活动
 
-- [AI Engineer World's Fair](https://www.ai.engineer/worldsfair) — 规模最大的 AI 工程会议；语音智能体分论坛曾有 ElevenLabs、Vapi、LiveKit、Pipecat、Cartesia 等重大发布。**🟢 入门**
-- [AI Engineer YouTube 频道](https://www.youtube.com/@aiDotEngineer) — World's Fair 与 Summit 演讲免费上线，语音智能体相关演讲的优质资源库。**🟢 入门**
-- [AI Engineer Summit Online：语音播放列表](https://www.youtube.com/playlist?list=PLcfpQ4tk2k0VetQVGT1EqTbcr-qcgbfFs) — 精选 YouTube 播放列表，含领先实验室的语音智能体相关场次。**🟢 入门**
-- [AIEWF 2025 Recap（Latent Space）](https://www.latent.space/p/aiewf-2025-keynotes) — 2025 语音智能体分论坛与重要发布的长文复盘。**🟢 入门**
-- [VOICE & AI（Modev）](https://www.voicesummit.ai/) — 长期聚焦语音智能体与语音技术的会议，覆盖更广的客户体验与语音机器人。**🟢 入门**
-- [Project Voice](https://www.projectvoice.ai/annual-conference) — 美国对话式 AI 主会之一，内容覆盖语音智能体、文本与聊天等形态。**🟢 入门**
-- [Interspeech](https://www.interspeech2025.org/) — 语音科学顶会；门槛高但值得关注——大量里程碑论文首发于此。**🔴 高阶**
+- [AI Engineer World's Fair](https://www.ai.engineer/worldsfair)：规模最大的 AI 工程会议；语音智能体分论坛曾有 ElevenLabs、Vapi、LiveKit、Pipecat、Cartesia 等重大发布。**🟢 入门**
+- [AI Engineer YouTube 频道](https://www.youtube.com/@aiDotEngineer)：World's Fair 与 Summit 演讲免费上线，语音智能体相关演讲的优质资源库。**🟢 入门**
+- [AI Engineer Summit Online：语音播放列表](https://www.youtube.com/playlist?list=PLcfpQ4tk2k0VetQVGT1EqTbcr-qcgbfFs)：精选 YouTube 播放列表，含领先实验室的语音智能体相关场次。**🟢 入门**
+- [AIEWF 2025 Recap（Latent Space）](https://www.latent.space/p/aiewf-2025-keynotes)：2025 语音智能体分论坛与重要发布的长文复盘。**🟢 入门**
+- [VOICE & AI（Modev）](https://www.voicesummit.ai/)：长期聚焦语音智能体与语音技术的会议，覆盖更广的客户体验与语音机器人。**🟢 入门**
+- [Project Voice](https://www.projectvoice.ai/annual-conference)：美国对话式 AI 主会之一，内容覆盖语音智能体、文本与聊天等形态。**🟢 入门**
+- [Interspeech](https://www.interspeech2025.org/)：语音科学顶会；门槛高但值得关注——大量里程碑论文首发于此。**🔴 高阶**
 
 ## 21. 黑客松与竞赛
 
-- [ElevenLabs Worldwide Hackathon](https://hackathon.elevenlabs.io/) — 全球语音智能体旗舰黑客松；30+ 城市，奖金池 $200K+。**🟢 入门**
-- [ElevenHacks（每周冲刺）](https://hacks.elevenlabs.io/) — 每周主题挑战，含额度与奖品；低压力「一周一项目」。**🟢 入门**
-- [AI Engineer World's Fair Hackathon](https://www.ai.engineer/worldsfair) — 与大会同期；$10K 奖金，3000+ AI 工程师评审，语音智能体相关项目与竞赛活跃。**🟡 进阶**
-- [lablab.ai AI Hackathons](https://lablab.ai/event) — 持续更新的短期线上黑客松日历，常有语音智能体厂商赞助。**🟢 入门**
-- [Devpost：Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai) — 集中检索进行中的语音智能体黑客松。**🟢 入门**
+- [ElevenLabs Worldwide Hackathon](https://hackathon.elevenlabs.io/)：全球语音智能体旗舰黑客松；30+ 城市，奖金池 $200K+。**🟢 入门**
+- [ElevenHacks（每周冲刺）](https://hacks.elevenlabs.io/)：每周主题挑战，含额度与奖品；低压力「一周一项目」。**🟢 入门**
+- [AI Engineer World's Fair Hackathon](https://www.ai.engineer/worldsfair)：与大会同期；$10K 奖金，3000+ AI 工程师评审，语音智能体相关项目与竞赛活跃。**🟡 进阶**
+- [lablab.ai AI Hackathons](https://lablab.ai/event)：持续更新的短期线上黑客松日历，常有语音智能体厂商赞助。**🟢 入门**
+- [Devpost：Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai)：集中检索进行中的语音智能体黑客松。**🟢 入门**
 
 ---
 


### PR DESCRIPTION
## Summary

A proofreading and maintenance pass over both `README.md` and `README_zh.md`, plus basic repo hygiene. No new resources are added in this PR (kept it review-friendly); content additions are noted as follow-ups below.

## Changes

**Formatting**
- Restore entry separators across both files. Every English entry had lost the separator between the link and its description (it rendered as a run-on); they now use `: `. The Chinese file is normalized to the fullwidth colon `：`.
- Remove a duplicate horizontal rule before the Companion book section.
- Fix the language switcher: the current language is now plain text (no self-link), with a clear `|` separator.
- Add a missing difficulty tag and clarify the intro note about which sections are tagged.

**Accuracy and freshness**
- Handbook line updated to "Available now" (the stated ship date had already passed).
- Moonshine size corrected to parameter counts (tiny 27M / base 61M).
- LiveKit turn detector described as a small transformer model (the current multilingual model is Qwen2.5-0.5B based, not SmolLM).
- FTC entry relabeled to match the page it actually links to.

**Links** (each verified by fetch)
- Repointed moved or dead links: Cartesia TTS quickstart, ElevenLabs prompting guide, Tavus turn-taking, Telnyx SIP trunk, Coval testing.
- Normalized `blog.livekit.io` links to `livekit.com/blog`.

**Hygiene**
- Added `.gitignore` (macOS, editors, node) and removed the stray `.DS_Store`.

## Verification
- Link counts unchanged (186 per file); no headings touched, so the table-of-contents anchors still resolve.
- No stray double-spaces or em dashes remain in the English file; Chinese prose dashes and Markdown hard-breaks are preserved.

## Follow-ups (not in this PR)
- Content additions: flesh out the single-vendor Audio enhancement section, and add Courses / Books / Avatars / RAG / codecs / voice-biometrics.
- A CI link-checker (lychee) and a `CONTRIBUTING.md` / PR template.
- The four "Discord" community entries still point at vendor homepages; "Cartesia Ink" still points at the docs root; "VOICE & AI" has rebranded to "AGENTIC AI Summit".
- Compress `banner.png` (currently ~1.5 MB).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added language switcher to introduction (English/Chinese)
  * Updated handbook section to reflect current Kindle availability
  * Refreshed resource catalog with updated descriptions and links across all sections
  * Enhanced Chinese documentation with improved formatting and clarity

* **Chores**
  * Added `.gitignore` configuration for development artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->