### PR TITLE
Add Hermes to Managed platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The frameworks below all let you wire STT, an LLM, and TTS together. **For open-
 - [Retell AI: Introduction & Quickstart](https://docs.retellai.com/general/introduction): Phone-agent platform with $10 free credit on signup. **🟢 Beginner**
 - [Bland AI: Send Your First Phone Call](https://www.bland.ai/blog/the-bland-ai-voice-call-api): Minimal API tutorial for placing your first AI phone call. **🟢 Beginner**
 - [ElevenLabs Agents: Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart): Build and embed a voice agent widget on any website in 5 minutes (formerly branded "Conversational AI," now ElevenAgents). **🟢 Beginner**
+- [Hermes: Operating platform for AI voice agencies](https://buildwithhermes.com): White-label managed platform that bundles voice agents with a built-in CRM, campaign orchestration and usage-based billing, so an agency runs one platform instead of stitching together Retell/VAPI, a CRM, Zapier, Stripe and Twilio. From $149/mo. **🟢 Beginner**
 
 ### Realtime / speech-to-speech APIs
 


### PR DESCRIPTION
Adds Hermes to section 2 > Managed platforms, alongside Vapi, Retell, Bland and ElevenLabs Agents.

Hermes is a managed, low-code platform for building and running AI voice agents, built for agencies. It bundles white-label voice agents with a native CRM, campaign orchestration and usage-based billing, so an agency operates one platform instead of wiring Retell/VAPI to a separate CRM, Zapier, Stripe and Twilio. It adds a white-label, agency-operations angle the current managed-platform entries don't cover.

Site: https://buildwithhermes.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Hermes: Operating platform for AI voice agencies” entry to the Managed platforms section, including its link and badge/tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->