### PR TITLE
Add Soniox to STT and TTS providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Pick **one streaming STT** and learn it deeply before shopping around. Deepgram,
 - [Deepgram Nova-3: STT benchmarks](https://deepgram.com/learn/speech-to-text-benchmarks): Primer on WER, latency, and cost alongside Deepgram's product reference; Nova-3 now spans 36+ languages with multilingual code-switching. **🟢 Beginner**
 - [AssemblyAI Universal-3 Pro](https://www.assemblyai.com/blog/build-voice-agent-function-calling): Streaming STT walkthrough that doubles as a function-calling tutorial; Universal-3 Pro is the current flagship, adding natural-language keyterm prompting. **🟡 Intermediate**
 - [OpenAI Whisper / gpt-4o-transcribe API docs](https://platform.openai.com/docs/guides/speech-to-text): Easiest cloud STT if you already use OpenAI. **🟢 Beginner**
-- [Soniox multilingual benchmark](https://soniox.com/benchmarks): Public WER comparison across 60 languages. **🟢 Beginner**
 - [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest): Streaming STT paired with Sonic TTS for a single-vendor low-latency stack. **🟢 Beginner**
+- [Soniox Speech-to-Text](https://soniox.com/docs/stt/get-started): One model spanning 60+ languages with real-time WebSocket streaming and async APIs, speaker diarization, language identification, endpoint detection, and built-in real-time speech translation (one-way or two-way). **🟢 Beginner**
 
 ### Open source
 
@@ -156,6 +156,7 @@ Pick **one streaming STT** and learn it deeply before shopping around. Deepgram,
 - [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest): Sonic 3.5, sub-90 ms first-byte latency, designed specifically for voice agents. **🟢 Beginner**
 - [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models): Low-latency streaming TTS (Aura-2) that pairs cleanly with Deepgram STT. **🟢 Beginner**
 - [OpenAI TTS (gpt-4o-mini-tts)](https://platform.openai.com/docs/guides/text-to-speech): Easiest plug-in TTS for the OpenAI stack. **🟢 Beginner**
+- [Soniox Text-to-Speech](https://soniox.com/docs/tts/get-started): Low-latency streaming TTS over WebSocket with multilingual voices; pairs with Soniox STT and translation. **🟢 Beginner**
 - [Artificial Analysis: TTS leaderboard](https://artificialanalysis.ai/text-to-speech/models): ELO, price, and speed comparison covering Rime, PlayHT, Hume, Inworld, and others. **🟢 Beginner**
 
 ### Open source

--- a/README_zh.md
+++ b/README_zh.md
@@ -128,8 +128,8 @@
 - [Deepgram Nova-3：STT 基准](https://deepgram.com/learn/speech-to-text-benchmarks)：在 WER、延迟与成本语境下介绍 Deepgram 产品；Nova-3 现已覆盖 36+ 种语言，并支持多语种混说（code-switching）。**🟢 入门**
 - [AssemblyAI Universal-3 Pro](https://www.assemblyai.com/blog/build-voice-agent-function-calling)：流式 STT 教程，同时可作为 function calling 示例；Universal-3 Pro 为当前旗舰，新增自然语言关键术语提示（keyterm prompting）。**🟡 进阶**
 - [OpenAI Whisper / gpt-4o-transcribe API 文档](https://platform.openai.com/docs/guides/speech-to-text)：若已用 OpenAI，这是最容易上手的云端 STT。**🟢 入门**
-- [Soniox 多语言基准](https://soniox.com/benchmarks)：公开 WER，覆盖约 60 种语言。**🟢 入门**
 - [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest)：流式 STT 搭配 Sonic TTS，单供应商低延迟栈。**🟢 入门**
+- [Soniox 语音转文字](https://soniox.com/docs/stt/get-started)：单模型覆盖 60+ 种语言，提供实时 WebSocket 流式与异步 API，支持话者分离、语种识别、话末检测，并内置实时语音翻译（单向或双向）。**🟢 入门**
 
 ### 开源
 
@@ -156,6 +156,7 @@
 - [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest)：Sonic 3.5，首字节低于 90 ms，面向语音智能体设计。**🟢 入门**
 - [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models)：低延迟流式 TTS（Aura-2），与 Deepgram STT 衔接顺畅。**🟢 入门**
 - [OpenAI TTS（gpt-4o-mini-tts）](https://platform.openai.com/docs/guides/text-to-speech)：OpenAI 栈里最容易接入的 TTS。**🟢 入门**
+- [Soniox 文字转语音](https://soniox.com/docs/tts/get-started)：低延迟流式 TTS（WebSocket，另有 REST API），多语种音色；与 Soniox STT 及翻译搭配，构成单供应商实时语音到语音栈。**🟢 入门**
 - [Artificial Analysis：TTS 榜单](https://artificialanalysis.ai/text-to-speech/models)：ELO、价格与速度对比，含 Rime、PlayHT、Hume、Inworld 等。**🟢 入门**
 
 ### 开源


### PR DESCRIPTION
## What

Adds [Soniox](https://soniox.com) to the Speech-to-Text and Text-to-Speech sections.

- **§3 STT → Commercial APIs**: new Soniox Speech-to-Text entry that points to actual Soniox API docs.
- **§4 TTS → Commercial APIs**: new Soniox Text-to-Speech entry.

Real-time translation has no dedicated section in the list, so it's folded into the STT entry since Soniox delivers it through the STT API.

## Why

Soniox covers all three pipeline stages (STT, TTS, real-time translation) but the list only referenced its old benchmark page. 

Both `README.md` and `README_zh.md` are updated to stay in sync.

## Disclosure

I work at Soniox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README provider lists for speech-to-text and text-to-speech.
  * Added new Soniox setup/get-started links for both speech-to-text and text-to-speech.
  * Adjusted the ordering and labels of the listed speech providers for clearer navigation.
  * Updated the Chinese README to reflect the same provider and onboarding changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->