### PR TITLE
docs: readability pass (emoji headers, quick-pick tables, collapsible long sections)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,319 +52,423 @@ The README you're reading collects the field's best free resources. The book is 
 <details>
 <summary><b>📖 Expand the 21 sections</b></summary>
 
-1. [Foundational concepts and learning paths](#1-foundational-concepts-and-learning-paths)
-2. [Frameworks and orchestration platforms](#2-frameworks-and-orchestration-platforms)
-3. [Speech-to-text (STT / ASR)](#3-speech-to-text-stt--asr)
-4. [Text-to-speech (TTS)](#4-text-to-speech-tts)
-5. [LLMs for voice and real-time AI](#5-llms-for-voice-and-real-time-ai)
-6. [Voice activity detection and turn-taking](#6-voice-activity-detection-and-turn-taking)
-7. [Audio enhancement and noise suppression](#7-audio-enhancement-and-noise-suppression)
-8. [WebRTC fundamentals](#8-webrtc-fundamentals)
-9. [Telephony and SIP](#9-telephony-and-sip)
-10. [Tutorials and hands-on projects](#10-tutorials-and-hands-on-projects)
-11. [GitHub starter repos and awesome lists](#11-github-starter-repos-and-awesome-lists)
-12. [Datasets and benchmarks](#12-datasets-and-benchmarks)
-13. [Beginner-accessible research papers](#13-beginner-accessible-research-papers)
-14. [Evaluation and testing](#14-evaluation-and-testing)
-15. [Production, deployment, and scaling](#15-production-deployment-and-scaling)
-16. [Ethics, safety, and regulation](#16-ethics-safety-and-regulation)
-17. [Blogs and newsletters](#17-blogs-and-newsletters)
-18. [Podcasts](#18-podcasts)
-19. [Communities](#19-communities)
-20. [Conferences and events](#20-conferences-and-events)
-21. [Hackathons and competitions](#21-hackathons-and-competitions)
+1. [Foundational concepts and learning paths](#-1-foundational-concepts-and-learning-paths)
+2. [Frameworks and orchestration platforms](#-2-frameworks-and-orchestration-platforms)
+3. [Speech-to-text (STT / ASR)](#-3-speech-to-text-stt--asr)
+4. [Text-to-speech (TTS)](#-4-text-to-speech-tts)
+5. [LLMs for voice and real-time AI](#-5-llms-for-voice-and-real-time-ai)
+6. [Voice activity detection and turn-taking](#-6-voice-activity-detection-and-turn-taking)
+7. [Audio enhancement and noise suppression](#-7-audio-enhancement-and-noise-suppression)
+8. [WebRTC fundamentals](#-8-webrtc-fundamentals)
+9. [Telephony and SIP](#-9-telephony-and-sip)
+10. [Tutorials and hands-on projects](#-10-tutorials-and-hands-on-projects)
+11. [GitHub starter repos and awesome lists](#-11-github-starter-repos-and-awesome-lists)
+12. [Datasets and benchmarks](#-12-datasets-and-benchmarks)
+13. [Beginner-accessible research papers](#-13-beginner-accessible-research-papers)
+14. [Evaluation and testing](#-14-evaluation-and-testing)
+15. [Production, deployment, and scaling](#-15-production-deployment-and-scaling)
+16. [Ethics, safety, and regulation](#-16-ethics-safety-and-regulation)
+17. [Blogs and newsletters](#-17-blogs-and-newsletters)
+18. [Podcasts](#-18-podcasts)
+19. [Communities](#-19-communities)
+20. [Conferences and events](#-20-conferences-and-events)
+21. [Hackathons and competitions](#-21-hackathons-and-competitions)
 
 </details>
 
 ---
 
-## 1. Foundational concepts and learning paths
+## 🧭 1. Foundational concepts and learning paths
 
 Start here. These resources establish the **mental model of the voice agent pipeline** and the latency budget you'll fight for the rest of your career.
 
-- [Voice AI & Voice Agents: An Illustrated Primer](https://voiceaiandvoiceagents.com/): Kwindla Hultman Kramer's free, regularly-updated long-form primer. The de facto textbook for the field. **🟢 Beginner**
-- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained (LiveKit)](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained): Visual walkthrough of streaming patterns, turn detection, and where latency accumulates. **🟢 Beginner**
-- [Everything You Need to Know About Voice AI Agents (Deepgram)](https://deepgram.com/learn/everything-about-voice-ai-agents): End-to-end primer covering feature extraction, ASR, LLM reasoning, and synthesis. **🟢 Beginner**
-- [AI Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/): The canonical "what is a voice agent" reference, covering the Agents framework, sessions, and the STT-LLM-TTS pipeline vs realtime model split. **🟢 Beginner**
-- [Core Latency in AI Voice Agents (Twilio)](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents): Visual explanation of end-of-turn detection, silence thresholds, and smart endpointing. **🟢 Beginner**
-- [Advice on Building Voice AI in June 2025 (Daily.co)](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/): Practical P50/P95 latency-budget guidance from Pipecat's creators. **🟡 Intermediate**
-- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents (AssemblyAI)](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent): Endpointing is the most underestimated problem; this is the clearest deep-dive. **🟡 Intermediate**
+<details>
+<summary><b>7 resources</b></summary>
 
-## 2. Frameworks and orchestration platforms
+- 🟢 [Voice AI & Voice Agents: An Illustrated Primer](https://voiceaiandvoiceagents.com/): Kwindla Hultman Kramer's free, regularly-updated long-form primer. The de facto textbook for the field.
+- 🟢 [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained (LiveKit)](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained): Visual walkthrough of streaming patterns, turn detection, and where latency accumulates.
+- 🟢 [Everything You Need to Know About Voice AI Agents (Deepgram)](https://deepgram.com/learn/everything-about-voice-ai-agents): End-to-end primer covering feature extraction, ASR, LLM reasoning, and synthesis.
+- 🟢 [AI Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/): The canonical "what is a voice agent" reference, covering the Agents framework, sessions, and the STT-LLM-TTS pipeline vs realtime model split.
+- 🟢 [Core Latency in AI Voice Agents (Twilio)](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents): Visual explanation of end-of-turn detection, silence thresholds, and smart endpointing.
+- 🟡 [Advice on Building Voice AI in June 2025 (Daily.co)](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/): Practical P50/P95 latency-budget guidance from Pipecat's creators.
+- 🟡 [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents (AssemblyAI)](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent): Endpointing is the most underestimated problem; this is the clearest deep-dive.
+
+</details>
+
+## 🧩 2. Frameworks and orchestration platforms
 
 The frameworks below all let you wire STT, an LLM, and TTS together. **For open-source production work, LiveKit Agents and Pipecat are the two safest bets**; for managed dashboards, Vapi, Retell, and Bland win on time-to-first-call.
 
+| Pick | Type | Best for |
+|------|------|----------|
+| **LiveKit Agents** | Open source | Production, WebRTC-native |
+| **Pipecat** | Open source | Vendor-neutral pipelines |
+| **Vapi / Retell / Bland** | Managed | Fastest first call |
+| **OpenAI Realtime / Gemini Live** | Realtime API | Speech-to-speech |
+
+<details>
+<summary><b>13 resources</b></summary>
+
 ### Open-source frameworks
 
-- [LiveKit Agents: Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Working assistant in <10 min via Python or TypeScript, runs on top of WebRTC. **🟢 Beginner**
-- [Pipecat: Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart): Scaffolds a Deepgram + OpenAI + Cartesia pipeline via the Pipecat CLI (`uv tool install pipecat-ai-cli`, then `pipecat init quickstart`); talk to it in the browser in ~5 minutes. **🟢 Beginner**
-- [Ultravox (fixie-ai/ultravox)](https://github.com/fixie-ai/ultravox): Open-weight multimodal speech LLM (Llama/Gemma/Qwen variants) that skips the separate ASR stage for ~150 ms TTFT. **🔴 Advanced**
-
+- 🟢 [LiveKit Agents: Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Working assistant in <10 min via Python or TypeScript, runs on top of WebRTC.
+- 🟢 [Pipecat: Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart): Scaffolds a Deepgram + OpenAI + Cartesia pipeline via the Pipecat CLI (`uv tool install pipecat-ai-cli`, then `pipecat init quickstart`); talk to it in the browser in ~5 minutes.
+- 🔴 [Ultravox (fixie-ai/ultravox)](https://github.com/fixie-ai/ultravox): Open-weight multimodal speech LLM (Llama/Gemma/Qwen variants) that skips the separate ASR stage for ~150 ms TTFT.
 ### Managed platforms
 
-- [Vapi: Quickstart](https://docs.vapi.ai/quickstart/introduction): Dashboard-first; ship an agent on a free US phone number in under 5 minutes. **🟢 Beginner**
-- [Retell AI: Introduction & Quickstart](https://docs.retellai.com/general/introduction): Phone-agent platform with $10 free credit on signup. **🟢 Beginner**
-- [Bland AI: Send Your First Phone Call](https://www.bland.ai/blog/the-bland-ai-voice-call-api): Minimal API tutorial for placing your first AI phone call. **🟢 Beginner**
-- [ElevenLabs Agents: Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart): Build and embed a voice agent widget on any website in 5 minutes (formerly branded "Conversational AI," now ElevenAgents). **🟢 Beginner**
-
+- 🟢 [Vapi: Quickstart](https://docs.vapi.ai/quickstart/introduction): Dashboard-first; ship an agent on a free US phone number in under 5 minutes.
+- 🟢 [Retell AI: Introduction & Quickstart](https://docs.retellai.com/general/introduction): Phone-agent platform with $10 free credit on signup.
+- 🟢 [Bland AI: Send Your First Phone Call](https://www.bland.ai/blog/the-bland-ai-voice-call-api): Minimal API tutorial for placing your first AI phone call.
+- 🟢 [ElevenLabs Agents: Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart): Build and embed a voice agent widget on any website in 5 minutes (formerly branded "Conversational AI," now ElevenAgents).
 ### Realtime / speech-to-speech APIs
 
-- [OpenAI Realtime API: Guide](https://developers.openai.com/api/docs/guides/realtime): Official guide to `gpt-realtime-2` (GA; GPT-5-class with configurable reasoning) over WebRTC, WebSockets, or SIP. **🟡 Intermediate**
-- [Google Gemini Live API: Overview](https://ai.google.dev/gemini-api/docs/live-api): Low-latency, bidirectional voice + vision agents with barge-in and tool use, on Gemini native audio. **🟡 Intermediate**
-- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay): WebSocket bridge that handles STT/TTS so you focus on LLM logic; works with any LLM. **🟡 Intermediate**
-
+- 🟡 [OpenAI Realtime API: Guide](https://developers.openai.com/api/docs/guides/realtime): Official guide to `gpt-realtime-2` (GA; GPT-5-class with configurable reasoning) over WebRTC, WebSockets, or SIP.
+- 🟡 [Google Gemini Live API: Overview](https://ai.google.dev/gemini-api/docs/live-api): Low-latency, bidirectional voice + vision agents with barge-in and tool use, on Gemini native audio.
+- 🟡 [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay): WebSocket bridge that handles STT/TTS so you focus on LLM logic; works with any LLM.
 ### Vendor-neutral comparisons
 
-- [Vapi vs Pipecat vs LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit): Architecture-focused comparison of pipeline control and transport choices. **🟡 Intermediate**
-- [11 Voice Agent Platforms Compared (Softcery)](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025): Broad market map with use-case recommendations. **🟢 Beginner**
-- [Best Voice Agent Stack (Hamming AI)](https://hamming.ai/resources/best-voice-agent-stack): Buy-vs-build framework with concrete cost, latency, and time-to-launch numbers. **🟡 Intermediate**
+- 🟡 [Vapi vs Pipecat vs LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit): Architecture-focused comparison of pipeline control and transport choices.
+- 🟢 [11 Voice Agent Platforms Compared (Softcery)](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025): Broad market map with use-case recommendations.
+- 🟡 [Best Voice Agent Stack (Hamming AI)](https://hamming.ai/resources/best-voice-agent-stack): Buy-vs-build framework with concrete cost, latency, and time-to-launch numbers.
 
-## 3. Speech-to-text (STT / ASR)
+</details>
 
-Pick **one streaming STT** and learn it deeply before shopping around. Deepgram, AssemblyAI, and Whisper-derivatives cover most use cases. (All-in-one ASR + end-of-turn models like Deepgram Flux are covered under [turn-taking](#6-voice-activity-detection-and-turn-taking).)
+## 🎧 3. Speech-to-text (STT / ASR)
+
+Pick **one streaming STT** and learn it deeply before shopping around. Deepgram, AssemblyAI, and Whisper-derivatives cover most use cases. (All-in-one ASR + end-of-turn models like Deepgram Flux are covered under [turn-taking](#-6-voice-activity-detection-and-turn-taking).)
+
+| Pick | Type | Best for |
+|------|------|----------|
+| **Deepgram Nova-3** | Commercial | General-purpose, 36+ languages |
+| **AssemblyAI Universal-3 Pro** | Commercial | Accuracy, diarization |
+| **Soniox** | Commercial | Multilingual + built-in translation |
+| **faster-whisper** | Open source | Self-hosted Whisper |
+| **NVIDIA Parakeet (NeMo)** | Open source | Top-of-leaderboard accuracy |
+
+<details>
+<summary><b>17 resources</b></summary>
 
 ### Commercial APIs
 
-- [Deepgram Nova-3: STT benchmarks](https://deepgram.com/learn/speech-to-text-benchmarks): Primer on WER, latency, and cost alongside Deepgram's product reference; Nova-3 spans 36+ languages with multilingual code-switching. **🟢 Beginner**
-- [AssemblyAI Universal-3 Pro Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling): Streaming STT walkthrough that doubles as a function-calling tutorial; Universal-3 Pro Streaming is the current real-time flagship, adding real-time diarization and keyterm prompting. **🟡 Intermediate**
-- [OpenAI Whisper / gpt-4o-transcribe API docs](https://developers.openai.com/api/docs/guides/speech-to-text): Easiest cloud STT if you already use OpenAI. **🟢 Beginner**
-- [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest): GA streaming STT with built-in eager turn detection and noise robustness, paired with Sonic TTS for a single-vendor low-latency stack. **🟢 Beginner**
-- [Soniox Speech-to-Text](https://soniox.com/docs/stt/get-started): One model spanning 60+ languages with real-time WebSocket streaming and async APIs, speaker diarization, language identification, endpoint detection, and built-in real-time speech translation (one-way or two-way). **🟢 Beginner**
-- [Speechmatics Melia](https://www.speechmatics.com/company/articles-and-news/introducing-melia-multilingual-speech-to-text-model): Single-pass multilingual STT with native code-switching across 56+ languages. **🟡 Intermediate**
-- [Gladia Solaria-3](https://www.gladia.io/blog/solaria-3-speech-to-text-model-for-european-languages): STT tuned for noisy, multi-speaker European business audio (9.6% WER on English production calls). **🟡 Intermediate**
-
+- 🟢 [Deepgram Nova-3: STT benchmarks](https://deepgram.com/learn/speech-to-text-benchmarks): Primer on WER, latency, and cost alongside Deepgram's product reference; Nova-3 spans 36+ languages with multilingual code-switching.
+- 🟡 [AssemblyAI Universal-3 Pro Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling): Streaming STT walkthrough that doubles as a function-calling tutorial; Universal-3 Pro Streaming is the current real-time flagship, adding real-time diarization and keyterm prompting.
+- 🟢 [OpenAI Whisper / gpt-4o-transcribe API docs](https://developers.openai.com/api/docs/guides/speech-to-text): Easiest cloud STT if you already use OpenAI.
+- 🟢 [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest): GA streaming STT with built-in eager turn detection and noise robustness, paired with Sonic TTS for a single-vendor low-latency stack.
+- 🟢 [Soniox Speech-to-Text](https://soniox.com/docs/stt/get-started): One model spanning 60+ languages with real-time WebSocket streaming and async APIs, speaker diarization, language identification, endpoint detection, and built-in real-time speech translation (one-way or two-way).
+- 🟡 [Speechmatics Melia](https://www.speechmatics.com/company/articles-and-news/introducing-melia-multilingual-speech-to-text-model): Single-pass multilingual STT with native code-switching across 56+ languages.
+- 🟡 [Gladia Solaria-3](https://www.gladia.io/blog/solaria-3-speech-to-text-model-for-european-languages): STT tuned for noisy, multi-speaker European business audio (9.6% WER on English production calls).
 ### Open source
 
-- [openai/whisper](https://github.com/openai/whisper): The original repo and the de facto starting point for any DIY ASR project. **🟢 Beginner**
-- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper): CTranslate2 reimplementation up to 4× faster with INT8; recommended for self-hosted Whisper. **🟡 Intermediate**
-- [NVIDIA NeMo (Parakeet / Canary)](https://github.com/NVIDIA-NeMo/Speech): Top-of-leaderboard open ASR models with streaming inference recipes. **🔴 Advanced**
-- [Moonshine](https://github.com/moonshine-ai/moonshine): Tiny on-device ASR (tiny 27M / base 61M params); v2 adds an ergodic streaming encoder built for latency-critical live transcription on edge devices. **🟡 Intermediate**
-- [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b): Open-weights cache-aware FastConformer streaming ASR across 40 locales, with runtime-configurable latency (80 ms to 1.1 s). **🔴 Advanced**
-
+- 🟢 [openai/whisper](https://github.com/openai/whisper): The original repo and the de facto starting point for any DIY ASR project.
+- 🟡 [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper): CTranslate2 reimplementation up to 4× faster with INT8; recommended for self-hosted Whisper.
+- 🔴 [NVIDIA NeMo (Parakeet / Canary)](https://github.com/NVIDIA-NeMo/Speech): Top-of-leaderboard open ASR models with streaming inference recipes.
+- 🟡 [Moonshine](https://github.com/moonshine-ai/moonshine): Tiny on-device ASR (tiny 27M / base 61M params); v2 adds an ergodic streaming encoder built for latency-critical live transcription on edge devices.
+- 🔴 [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b): Open-weights cache-aware FastConformer streaming ASR across 40 locales, with runtime-configurable latency (80 ms to 1.1 s).
 ### Benchmarks and explainers
 
-- [Open ASR Leaderboard (HuggingFace)](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Community leaderboard across 11 datasets: your reference for open-source picks. **🟢 Beginner**
-- [Artificial Analysis: Speech-to-Text](https://artificialanalysis.ai/speech-to-text): Independent leaderboard ranking 48+ STT providers by WER, speed, and cost. **🟢 Beginner**
-- [Best Speech-to-Text Providers in 2026 (Coval)](https://www.coval.ai/blog/best-speech-to-text-providers-in-2026-independent-benchmarks-and-how-to-choose/): Independent benchmark across 14 providers (WER, latency, end-of-turn, cost), with guidance on testing against your own traffic. **🟡 Intermediate**
-- [Best Speech-to-Text APIs in 2026 (Deepgram)](https://deepgram.com/learn/best-speech-to-text-apis-2026): Provider comparison guide; note the commercial author. **🟢 Beginner**
-- [Streaming vs Batch ASR (Arun Baby)](https://www.arunbaby.com/speech-tech/0001-streaming-asr/): Engineer-friendly explainer of RNN-T and Conformer streaming architectures. **🟡 Intermediate**
+- 🟢 [Open ASR Leaderboard (HuggingFace)](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Community leaderboard across 11 datasets: your reference for open-source picks.
+- 🟢 [Artificial Analysis: Speech-to-Text](https://artificialanalysis.ai/speech-to-text): Independent leaderboard ranking 48+ STT providers by WER, speed, and cost.
+- 🟡 [Best Speech-to-Text Providers in 2026 (Coval)](https://www.coval.ai/blog/best-speech-to-text-providers-in-2026-independent-benchmarks-and-how-to-choose/): Independent benchmark across 14 providers (WER, latency, end-of-turn, cost), with guidance on testing against your own traffic.
+- 🟢 [Best Speech-to-Text APIs in 2026 (Deepgram)](https://deepgram.com/learn/best-speech-to-text-apis-2026): Provider comparison guide; note the commercial author.
+- 🟡 [Streaming vs Batch ASR (Arun Baby)](https://www.arunbaby.com/speech-tech/0001-streaming-asr/): Engineer-friendly explainer of RNN-T and Conformer streaming architectures.
 
-## 4. Text-to-speech (TTS)
+</details>
+
+## 🗣️ 4. Text-to-speech (TTS)
 
 **Latency, not raw quality, is what kills voice agents**: prioritize providers offering true streaming with first-byte under 200 ms.
 
+| Pick | Type | Best for |
+|------|------|----------|
+| **ElevenLabs** | Commercial | Quality, voice cloning |
+| **Cartesia Sonic** | Commercial | Lowest latency for agents |
+| **Deepgram Aura-2** | Commercial | Pairs with Deepgram STT |
+| **Kokoro** | Open source | Tiny, CPU-friendly |
+| **Chatterbox** | Open source | Cloning + emotion control |
+
+<details>
+<summary><b>15 resources</b></summary>
+
 ### Commercial APIs
 
-- [ElevenLabs Docs](https://elevenlabs.io/docs): Industry-leading quality, voice cloning, and Agents platform in one SDK. **🟢 Beginner**
-- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest): Sonic 3.5 (42 languages, native turn detection), sub-90 ms first-byte latency, designed specifically for voice agents. **🟢 Beginner**
-- [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models): Low-latency streaming TTS (Aura-2) that pairs cleanly with Deepgram STT. **🟢 Beginner**
-- [OpenAI TTS (gpt-4o-mini-tts)](https://developers.openai.com/api/docs/guides/text-to-speech): Easiest plug-in TTS for the OpenAI stack. **🟢 Beginner**
-- [Soniox Text-to-Speech](https://soniox.com/docs/tts/get-started): Low-latency streaming TTS over WebSocket with multilingual voices; pairs with Soniox STT and translation. **🟢 Beginner**
-- [Artificial Analysis: TTS leaderboard](https://artificialanalysis.ai/text-to-speech/models): ELO, price, and speed comparison covering Rime, PlayHT, Hume, Inworld, and others. **🟢 Beginner**
-- [Best Text-to-Speech Providers in 2026 (Coval)](https://www.coval.ai/blog/best-text-to-speech-providers-in-2026-how-to-choose-%28and-why-vendor-benchmarks-lie%29/): Independent head-to-head of 14 TTS providers on latency, naturalness, and cost; note the commercial author. **🟡 Intermediate**
-
+- 🟢 [ElevenLabs Docs](https://elevenlabs.io/docs): Industry-leading quality, voice cloning, and Agents platform in one SDK.
+- 🟢 [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest): Sonic 3.5 (42 languages, native turn detection), sub-90 ms first-byte latency, designed specifically for voice agents.
+- 🟢 [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models): Low-latency streaming TTS (Aura-2) that pairs cleanly with Deepgram STT.
+- 🟢 [OpenAI TTS (gpt-4o-mini-tts)](https://developers.openai.com/api/docs/guides/text-to-speech): Easiest plug-in TTS for the OpenAI stack.
+- 🟢 [Soniox Text-to-Speech](https://soniox.com/docs/tts/get-started): Low-latency streaming TTS over WebSocket with multilingual voices; pairs with Soniox STT and translation.
+- 🟢 [Artificial Analysis: TTS leaderboard](https://artificialanalysis.ai/text-to-speech/models): ELO, price, and speed comparison covering Rime, PlayHT, Hume, Inworld, and others.
+- 🟡 [Best Text-to-Speech Providers in 2026 (Coval)](https://www.coval.ai/blog/best-text-to-speech-providers-in-2026-how-to-choose-%28and-why-vendor-benchmarks-lie%29/): Independent head-to-head of 14 TTS providers on latency, naturalness, and cost; note the commercial author.
 ### Open source
 
-- [Chatterbox (resemble-ai/chatterbox)](https://github.com/resemble-ai/chatterbox): Resemble AI's MIT-licensed TTS that beats ElevenLabs in blind preference tests; ~5 s zero-shot voice cloning, emotion-exaggeration control, and a built-in PerTh watermark. Turbo variant (350M) hits sub-150 ms first audio; Multilingual (V3, 0.5B) covers 23+ languages. **🟡 Intermediate**
-- [Kokoro 82M](https://github.com/hexgrad/kokoro): Tiny Apache-licensed model that tops community ELO arenas; runs on CPU. **🟢 Beginner**
-- [Piper (OHF-Voice/piper1-gpl)](https://github.com/OHF-Voice/piper1-gpl): Fast local neural TTS optimized for Raspberry Pi; perfect for offline projects. **🟢 Beginner**
-- [Coqui TTS (idiap fork)](https://github.com/idiap/coqui-ai-TTS): Maintained fork of Coqui-TTS / XTTS v2; still battle-tested, though Chatterbox now leads on zero-shot cloning quality. **🟡 Intermediate**
-- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS): Llama-3B-based emotive TTS with ~200 ms streaming and emotion tags. **🟡 Intermediate**
-- [Sesame CSM](https://github.com/SesameAILabs/csm): Conversational, context-aware multi-speaker TTS using a Llama backbone with the Mimi codec. **🔴 Advanced**
-
+- 🟡 [Chatterbox (resemble-ai/chatterbox)](https://github.com/resemble-ai/chatterbox): Resemble AI's MIT-licensed TTS that beats ElevenLabs in blind preference tests; ~5 s zero-shot voice cloning, emotion-exaggeration control, and a built-in PerTh watermark. Turbo variant (350M) hits sub-150 ms first audio; Multilingual (V3, 0.5B) covers 23+ languages.
+- 🟢 [Kokoro 82M](https://github.com/hexgrad/kokoro): Tiny Apache-licensed model that tops community ELO arenas; runs on CPU.
+- 🟢 [Piper (OHF-Voice/piper1-gpl)](https://github.com/OHF-Voice/piper1-gpl): Fast local neural TTS optimized for Raspberry Pi; perfect for offline projects.
+- 🟡 [Coqui TTS (idiap fork)](https://github.com/idiap/coqui-ai-TTS): Maintained fork of Coqui-TTS / XTTS v2; still battle-tested, though Chatterbox now leads on zero-shot cloning quality.
+- 🟡 [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS): Llama-3B-based emotive TTS with ~200 ms streaming and emotion tags.
+- 🔴 [Sesame CSM](https://github.com/SesameAILabs/csm): Conversational, context-aware multi-speaker TTS using a Llama backbone with the Mimi codec.
 ### Streaming and ethics
 
-- [Streaming TTS for Low-Latency Agents (Picovoice)](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/): Clear taxonomy of single, output-streaming, and dual-streaming TTS. **🟡 Intermediate**
-- [Ethics of Voice Cloning & Deepfakes (Deepgram)](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes): Vendor-neutral discussion of misuse, regulation, and developer responsibility. **🟢 Beginner**
+- 🟡 [Streaming TTS for Low-Latency Agents (Picovoice)](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/): Clear taxonomy of single, output-streaming, and dual-streaming TTS.
+- 🟢 [Ethics of Voice Cloning & Deepfakes (Deepgram)](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes): Vendor-neutral discussion of misuse, regulation, and developer responsibility.
 
-## 5. LLMs for voice and real-time AI
+</details>
+
+## 🧠 5. LLMs for voice and real-time AI
 
 A voice agent's perceived intelligence is bounded by **how fast the LLM streams its first token**. Sub-300 ms TTFT changes the conversation feel entirely.
 
+<details>
+<summary><b>11 resources</b></summary>
+
 ### Low-latency inference
 
-- [Groq](https://groq.com/): LPU-based inference cloud delivering ~10× faster Llama tokens/sec than commodity GPUs. **🟢 Beginner**
-- [Cerebras Inference](https://www.cerebras.ai/inference): Wafer-scale chip inference with very high throughput on Llama models. **🟢 Beginner**
-- [SambaNova Cloud](https://cloud.sambanova.ai/): Reconfigurable Dataflow inference; stable throughput at low latency. **🟢 Beginner**
-
+- 🟢 [Groq](https://groq.com/): LPU-based inference cloud delivering ~10× faster Llama tokens/sec than commodity GPUs.
+- 🟢 [Cerebras Inference](https://www.cerebras.ai/inference): Wafer-scale chip inference with very high throughput on Llama models.
+- 🟢 [SambaNova Cloud](https://cloud.sambanova.ai/): Reconfigurable Dataflow inference; stable throughput at low latency.
 ### Speech-to-speech models
 
-- [OpenAI Realtime API guide](https://developers.openai.com/api/docs/guides/realtime): Flagship S2S product with WebRTC/WebSocket transport (`gpt-realtime-2`, GA). **🟡 Intermediate**
-- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api): Real-time multimodal voice/video with barge-in and broad language support, on Gemini native audio. **🟡 Intermediate**
-- [Moshi (kyutai-labs)](https://github.com/kyutai-labs/moshi): Open full-duplex speech-text foundation model (~200 ms, Mimi codec). Kyutai's broader stack now includes Unmute (cascaded STT+LLM+TTS with tool use), Kyutai STT/TTS, and Hibiki (streaming translation). **🔴 Advanced**
-- [Speech-to-Speech Models in 2026: Three Architectural Bets (Krzysztof Sopyla)](https://ai.ksopyla.com/posts/voice-to-voice-models-2026-review/): Vendor-neutral comparison of full-duplex (Moshi), near-duplex multimodal (Qwen-Omni), and cascade approaches, with FullDuplexBench numbers and tradeoffs. **🟡 Intermediate**
-
+- 🟡 [OpenAI Realtime API guide](https://developers.openai.com/api/docs/guides/realtime): Flagship S2S product with WebRTC/WebSocket transport (`gpt-realtime-2`, GA).
+- 🟡 [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api): Real-time multimodal voice/video with barge-in and broad language support, on Gemini native audio.
+- 🔴 [Moshi (kyutai-labs)](https://github.com/kyutai-labs/moshi): Open full-duplex speech-text foundation model (~200 ms, Mimi codec). Kyutai's broader stack now includes Unmute (cascaded STT+LLM+TTS with tool use), Kyutai STT/TTS, and Hibiki (streaming translation).
+- 🟡 [Speech-to-Speech Models in 2026: Three Architectural Bets (Krzysztof Sopyla)](https://ai.ksopyla.com/posts/voice-to-voice-models-2026-review/): Vendor-neutral comparison of full-duplex (Moshi), near-duplex multimodal (Qwen-Omni), and cascade approaches, with FullDuplexBench numbers and tradeoffs.
 ### Voice-specific prompting and tools
 
-- [OpenAI Voice Agents Guide](https://developers.openai.com/api/docs/guides/voice-agents): Compares chained vs S2S architectures with prompt and tool best practices. **🟢 Beginner**
-- [ElevenLabs Voice Agent Prompting Guide](https://elevenlabs.io/docs/eleven-agents/best-practices/prompting-guide): Production-grade prompt structure tuned for voice; vendor-neutral lessons. **🟡 Intermediate**
-- [Voice AI Prompt Engineering Guide (VoiceInfra)](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide): Explains why voice prompts must be 60–70% shorter than chat prompts, with templates. **🟢 Beginner**
-- [Tool Definition and Use for Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/logic/tools/definition/): Defining `@function_tool` tools and raw-schema tools inside a voice agent. **🟡 Intermediate**
+- 🟢 [OpenAI Voice Agents Guide](https://developers.openai.com/api/docs/guides/voice-agents): Compares chained vs S2S architectures with prompt and tool best practices.
+- 🟡 [ElevenLabs Voice Agent Prompting Guide](https://elevenlabs.io/docs/eleven-agents/best-practices/prompting-guide): Production-grade prompt structure tuned for voice; vendor-neutral lessons.
+- 🟢 [Voice AI Prompt Engineering Guide (VoiceInfra)](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide): Explains why voice prompts must be 60–70% shorter than chat prompts, with templates.
+- 🟡 [Tool Definition and Use for Voice Agents (LiveKit Docs)](https://docs.livekit.io/agents/logic/tools/definition/): Defining `@function_tool` tools and raw-schema tools inside a voice agent.
 
-## 6. Voice activity detection and turn-taking
+</details>
+
+## 🔀 6. Voice activity detection and turn-taking
 
 Pure VAD is no longer enough: modern agents combine **acoustic VAD with a small semantic model** that predicts end-of-utterance from words and prosody.
 
-- [Silero VAD](https://github.com/snakers4/silero-vad): MIT-licensed pre-trained VAD; <1 ms per chunk on CPU. The de facto VAD inside LiveKit and Pipecat. **🟢 Beginner**
-- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad): Python bindings for Google's classic WebRTC VAD; lightweight baseline. **🟢 Beginner**
-- [LiveKit Turn Detector: blog post](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection): How a small transformer-based EOU model complements VAD with semantic context. **🟡 Intermediate**
-- [LiveKit turn-detector model on HuggingFace](https://huggingface.co/livekit/turn-detector): Open-weights multilingual EOU model running ONNX on CPU in under 500 MB. **🟡 Intermediate**
-- [LiveKit Turn Detector v1.0](https://livekit.com/blog/solving-end-of-turn-detection): Audio-native end-of-turn model (fused semantic + acoustic, no transcript) across 14 languages; now the LiveKit default. **🟡 Intermediate**
-- [Deepgram Flux](https://deepgram.com/learn/fluxing-conversational-state-and-speech-to-text): All-in-one conversational STT with built-in end-of-turn detection (median EOT <300 ms), integrated with Deepgram's Voice Agent API; collapses STT and turn detection into a single model. **🟡 Intermediate**
-- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/): Whisper-Tiny-based audio semantic VAD with fast CPU inference (~12 ms on a standard instance per the v3 repo), BSD-2 licensed. **🟡 Intermediate**
-- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn): Repo with model code, training scripts, and integration examples (~8M params, Whisper-Tiny base). **🟡 Intermediate**
-- [Krisp Turn-Taking](https://krisp.ai/): Commercial turn-taking model used alongside any STT/LLM/TTS stack. **🟡 Intermediate**
-- [The Complete Guide to AI Turn-Taking (Tavus)](https://www.tavus.io/blog/ai-turn-taking): Reader-friendly overview of why pure VAD fails in real conversations. **🟢 Beginner**
-- [Tackling Turn Detection in Voice AI (Notch)](https://www.notch.cx/post/turn-detection-in-voice-ai): Engineer-first walkthrough combining VAD probability, volume, and TTS markers. **🟡 Intermediate**
-- [What Is Endpointing in Voice AI? (Cekura)](https://www.cekura.ai/blogs/endpointing-in-voice-ai-turn-detection): Explainer on the three-signal endpointing stack with a testing angle; note the commercial author. **🟡 Intermediate**
-- [Evaluating End-of-Turn Detection Models (Deepgram)](https://deepgram.com/learn/evaluating-end-of-turn-detection-models): Methodology plus a head-to-head of Flux, Pipecat Smart Turn, and LiveKit EOU; note the commercial author. **🟡 Intermediate**
-- [ai-coustics VAD](https://developers.ai-coustics.com/): VAD bundled with real-time speech enhancement, noise suppression, and voice isolation in a single audio preprocessing SDK; useful when you want cleanup and turn-taking signals from the same component. **🟢 Beginner**
+<details>
+<summary><b>14 resources</b></summary>
 
-## 7. Audio enhancement and noise suppression
+- 🟢 [Silero VAD](https://github.com/snakers4/silero-vad): MIT-licensed pre-trained VAD; <1 ms per chunk on CPU. The de facto VAD inside LiveKit and Pipecat.
+- 🟢 [py-webrtcvad](https://github.com/wiseman/py-webrtcvad): Python bindings for Google's classic WebRTC VAD; lightweight baseline.
+- 🟡 [LiveKit Turn Detector: blog post](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection): How a small transformer-based EOU model complements VAD with semantic context.
+- 🟡 [LiveKit turn-detector model on HuggingFace](https://huggingface.co/livekit/turn-detector): Open-weights multilingual EOU model running ONNX on CPU in under 500 MB.
+- 🟡 [LiveKit Turn Detector v1.0](https://livekit.com/blog/solving-end-of-turn-detection): Audio-native end-of-turn model (fused semantic + acoustic, no transcript) across 14 languages; now the LiveKit default.
+- 🟡 [Deepgram Flux](https://deepgram.com/learn/fluxing-conversational-state-and-speech-to-text): All-in-one conversational STT with built-in end-of-turn detection (median EOT <300 ms), integrated with Deepgram's Voice Agent API; collapses STT and turn detection into a single model.
+- 🟡 [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/): Whisper-Tiny-based audio semantic VAD with fast CPU inference (~12 ms on a standard instance per the v3 repo), BSD-2 licensed.
+- 🟡 [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn): Repo with model code, training scripts, and integration examples (~8M params, Whisper-Tiny base).
+- 🟡 [Krisp Turn-Taking](https://krisp.ai/): Commercial turn-taking model used alongside any STT/LLM/TTS stack.
+- 🟢 [The Complete Guide to AI Turn-Taking (Tavus)](https://www.tavus.io/blog/ai-turn-taking): Reader-friendly overview of why pure VAD fails in real conversations.
+- 🟡 [Tackling Turn Detection in Voice AI (Notch)](https://www.notch.cx/post/turn-detection-in-voice-ai): Engineer-first walkthrough combining VAD probability, volume, and TTS markers.
+- 🟡 [What Is Endpointing in Voice AI? (Cekura)](https://www.cekura.ai/blogs/endpointing-in-voice-ai-turn-detection): Explainer on the three-signal endpointing stack with a testing angle; note the commercial author.
+- 🟡 [Evaluating End-of-Turn Detection Models (Deepgram)](https://deepgram.com/learn/evaluating-end-of-turn-detection-models): Methodology plus a head-to-head of Flux, Pipecat Smart Turn, and LiveKit EOU; note the commercial author.
+- 🟢 [ai-coustics VAD](https://developers.ai-coustics.com/): VAD bundled with real-time speech enhancement, noise suppression, and voice isolation in a single audio preprocessing SDK; useful when you want cleanup and turn-taking signals from the same component.
+
+</details>
+
+## 🔊 7. Audio enhancement and noise suppression
 
 The audio reaching your VAD and STT is often noisy, reverberant, or mixed with background voices. **Cleaning the signal before the rest of the pipeline** is frequently the difference between an agent that ships and one that frustrates users in real-world conditions (cars, cafés, call centres). In 2026 every major voice-AI vendor ships a deep-learning suppressor on top of WebRTC's classic noise-suppression chain.
 
-- [ai-coustics](https://ai-coustics.com/): Real-time speech enhancement SDK covering noise cancellation, voice isolation, and VAD; on-device and cloud deployment. See the [docs](https://docs.ai-coustics.com/) and [developer platform](https://developers.ai-coustics.com/). **🟢 Beginner**
-- [Krisp SDK](https://krisp.ai/): Commercial-grade real-time noise and background-voice cancellation; the de facto standard for voice comms (Python, Node.js, Go, C++ SDKs). LiveKit's background voice cancellation and Pipecat Cloud both build on Krisp. Enterprise access via contact form. **🟢 Beginner**
-- [DeepFilterNet (Rikorose/DeepFilterNet)](https://github.com/Rikorose/DeepFilterNet): Open-source, low-complexity real-time speech enhancement for full-band audio; designed to run on embedded devices. The strongest actively-developed OSS noise suppressor. **🟡 Intermediate**
-- [RNNoise (xiph/rnnoise)](https://github.com/xiph/rnnoise): Classic hybrid DSP + deep-learning noise suppression; a tiny, well-understood baseline, but no longer actively maintained. **🟡 Intermediate**
-- [Koala Noise Suppression (Picovoice)](https://picovoice.ai/platform/koala/): On-device, cross-platform voice isolation with self-serve access (browser, mobile, desktop, Raspberry Pi). **🟢 Beginner**
-- [Noise Suppression Guide 2026 (Picovoice)](https://picovoice.ai/blog/complete-guide-to-noise-suppression/): Algorithms, intelligibility metrics (SII / STI / STOI), and implementation tradeoffs; note the commercial author. **🟡 Intermediate**
+<details>
+<summary><b>6 resources</b></summary>
 
-## 8. WebRTC fundamentals
+- 🟢 [ai-coustics](https://ai-coustics.com/): Real-time speech enhancement SDK covering noise cancellation, voice isolation, and VAD; on-device and cloud deployment. See the [docs](https://docs.ai-coustics.com/) and [developer platform](https://developers.ai-coustics.com/).
+- 🟢 [Krisp SDK](https://krisp.ai/): Commercial-grade real-time noise and background-voice cancellation; the de facto standard for voice comms (Python, Node.js, Go, C++ SDKs). LiveKit's background voice cancellation and Pipecat Cloud both build on Krisp. Enterprise access via contact form.
+- 🟡 [DeepFilterNet (Rikorose/DeepFilterNet)](https://github.com/Rikorose/DeepFilterNet): Open-source, low-complexity real-time speech enhancement for full-band audio; designed to run on embedded devices. The strongest actively-developed OSS noise suppressor.
+- 🟡 [RNNoise (xiph/rnnoise)](https://github.com/xiph/rnnoise): Classic hybrid DSP + deep-learning noise suppression; a tiny, well-understood baseline, but no longer actively maintained.
+- 🟢 [Koala Noise Suppression (Picovoice)](https://picovoice.ai/platform/koala/): On-device, cross-platform voice isolation with self-serve access (browser, mobile, desktop, Raspberry Pi).
+- 🟡 [Noise Suppression Guide 2026 (Picovoice)](https://picovoice.ai/blog/complete-guide-to-noise-suppression/): Algorithms, intelligibility metrics (SII / STI / STOI), and implementation tradeoffs; note the commercial author.
+
+</details>
+
+## 🌐 8. WebRTC fundamentals
 
 WebRTC is the **default transport for voice agents** that don't run over the phone network. Understanding ICE, STUN, TURN, and SFU architecture is non-negotiable for production work.
 
-- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API): Authoritative free reference for `RTCPeerConnection`, `getUserMedia`, and signaling. **🟢 Beginner**
-- [MDN: Introduction to WebRTC Protocols](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols): Beginner-friendly explanation of ICE, STUN, TURN, and SDP. **🟢 Beginner**
-- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview): Official Google-maintained intro, splitting WebRTC into media-capture and connectivity. **🟢 Beginner**
-- [GetStream: WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/): Free multi-module tutorial covering networking basics through advanced topics. **🟢 Beginner**
-- [Why WebRTC Beats WebSockets for Voice AI (LiveKit)](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents): 2025 explainer aimed at AI builders, comparing transports in plain English. **🟡 Intermediate**
-- [Daily Docs: Intro to Video Architecture (P2P vs SFU)](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch): One of the clearest beginner write-ups of P2P vs SFU. **🟢 Beginner**
-- [P2P, SFU, MCU, Hybrid: WebRTC Architecture Guide (Forasoft)](https://www.forasoft.com/blog/article/webrtc-architecture-guide-for-business-2026): Vendor-neutral 2026 breakdown of the four architectures with current OSS tooling (mediasoup, Janus, Jitsi). **🟡 Intermediate**
-- [Agora: How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/): Side-by-side WebRTC vs WebSockets walkthrough with signaling diagrams. **🟢 Beginner**
+<details>
+<summary><b>8 resources</b></summary>
 
-## 9. Telephony and SIP
+- 🟢 [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API): Authoritative free reference for `RTCPeerConnection`, `getUserMedia`, and signaling.
+- 🟢 [MDN: Introduction to WebRTC Protocols](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols): Beginner-friendly explanation of ICE, STUN, TURN, and SDP.
+- 🟢 [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview): Official Google-maintained intro, splitting WebRTC into media-capture and connectivity.
+- 🟢 [GetStream: WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/): Free multi-module tutorial covering networking basics through advanced topics.
+- 🟡 [Why WebRTC Beats WebSockets for Voice AI (LiveKit)](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents): 2025 explainer aimed at AI builders, comparing transports in plain English.
+- 🟢 [Daily Docs: Intro to Video Architecture (P2P vs SFU)](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch): One of the clearest beginner write-ups of P2P vs SFU.
+- 🟡 [P2P, SFU, MCU, Hybrid: WebRTC Architecture Guide (Forasoft)](https://www.forasoft.com/blog/article/webrtc-architecture-guide-for-business-2026): Vendor-neutral 2026 breakdown of the four architectures with current OSS tooling (mediasoup, Janus, Jitsi).
+- 🟢 [Agora: How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/): Side-by-side WebRTC vs WebSockets walkthrough with signaling diagrams.
+
+</details>
+
+## ☎️ 9. Telephony and SIP
 
 The phone network has its own physics. Once you know which **SIP trunk provider** to point at LiveKit or Pipecat, you can ship.
 
-- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice): TwiML, Voice API, and PSTN connectivity in one hub; the default starting point. **🟢 Beginner**
-- [Twilio: Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python): Step-by-step junior-friendly tutorial wiring Twilio Media Streams to an LLM. **🟢 Beginner**
-- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart): Clearest beginner explainer of SIP basics, SIP Domains, and softphone setup. **🟢 Beginner**
-- [Telnyx Voice API](https://telnyx.com/products/voice-api): Strong Twilio alternative with WebSocket media streaming and AI Assistant tooling. **🟢 Beginner**
-- [Telnyx: How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk): Friendly walkthrough of SIP trunking architecture, codecs, and authentication. **🟢 Beginner**
-- [Plivo Voice API Documentation](https://www.plivo.com/docs/voice/): XML call control and audio-streaming integrations for AI agents. **🟢 Beginner**
-- [SignalWire Voice Docs](https://signalwire.com/docs/platform/voice): Built on FreeSWITCH; SWML, TwiML-compatible API, and an AI Agents SDK. **🟡 Intermediate**
-- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/): Best diagram of how a call flows from PSTN → trunk → SIP service → agent. **🟢 Beginner**
-- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/): Practical guide for wiring Twilio/Telnyx/Plivo/Wavix/Sinch trunks into LiveKit. **🟡 Intermediate**
-- [Pipecat Telephony Overview](https://docs.pipecat.ai/pipecat/telephony/overview): Differences between WebSocket-based telephony and SIP-based call control. **🟡 Intermediate**
+| Pick | Type | Best for |
+|------|------|----------|
+| **Twilio** | Commercial | Default, largest ecosystem |
+| **Telnyx / Plivo** | Commercial | Cost-effective SIP trunks |
+| **SignalWire** | Commercial | FreeSWITCH-based, programmable |
+| **LiveKit SIP / Pipecat** | Framework | Wire trunks into your agent |
 
-## 10. Tutorials and hands-on projects
+<details>
+<summary><b>10 resources</b></summary>
+
+- 🟢 [Twilio Programmable Voice](https://www.twilio.com/en-us/voice): TwiML, Voice API, and PSTN connectivity in one hub; the default starting point.
+- 🟢 [Twilio: Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python): Step-by-step junior-friendly tutorial wiring Twilio Media Streams to an LLM.
+- 🟢 [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart): Clearest beginner explainer of SIP basics, SIP Domains, and softphone setup.
+- 🟢 [Telnyx Voice API](https://telnyx.com/products/voice-api): Strong Twilio alternative with WebSocket media streaming and AI Assistant tooling.
+- 🟢 [Telnyx: How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk): Friendly walkthrough of SIP trunking architecture, codecs, and authentication.
+- 🟢 [Plivo Voice API Documentation](https://www.plivo.com/docs/voice/): XML call control and audio-streaming integrations for AI agents.
+- 🟡 [SignalWire Voice Docs](https://signalwire.com/docs/platform/voice): Built on FreeSWITCH; SWML, TwiML-compatible API, and an AI Agents SDK.
+- 🟢 [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/): Best diagram of how a call flows from PSTN → trunk → SIP service → agent.
+- 🟡 [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/): Practical guide for wiring Twilio/Telnyx/Plivo/Wavix/Sinch trunks into LiveKit.
+- 🟡 [Pipecat Telephony Overview](https://docs.pipecat.ai/pipecat/telephony/overview): Differences between WebSocket-based telephony and SIP-based call control.
+
+</details>
+
+## 🛠️ 10. Tutorials and hands-on projects
 
 Pick **one tutorial and finish it before starting another**. Voice AI is unforgiving of half-built pipelines.
 
-- [LiveKit Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Official 10-minute walkthrough in Python or Node with starter templates. **🟢 Beginner**
-- [Build Your First AI Voice Agent in Python (LiveKit)](https://livekit.com/blog/build-your-first-ai-voice-agent-python): End-to-end Python tutorial covering streaming, latency, and deployment. **🟢 Beginner**
-- [Pipecat Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart): Build and deploy a Deepgram + OpenAI + Cartesia bot via the Pipecat CLI in roughly 10 minutes. **🟢 Beginner**
-- [How to Build a Real-Time Voice Agent with Pipecat (AssemblyAI)](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat): Production-oriented walkthrough including local testing and Pipecat Cloud deployment. **🟡 Intermediate**
-- [Build a Voice Agent with LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/build-voice-agent-livekit): End-to-end walkthrough wiring LiveKit Agents + AssemblyAI Universal-3 Pro + Cartesia, run locally then on the Agents Playground. **🟡 Intermediate**
-- [Deepgram: Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent): Step-by-step guide wiring Deepgram STT, GPT, and Aura TTS. **🟢 Beginner**
-- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python): Provider-agnostic tutorial supporting OpenAI, Anthropic, or DeepSeek. **🟡 Intermediate**
-- [freeCodeCamp: Build Advanced AI Agents (LiveKit, Exa, LangChain)](https://www.youtube.com/watch?v=B0TJC4lmzEM): Free 3-part video course covering interactive voice agents end-to-end. **🟢 Beginner**
-- [freeCodeCamp: Build a Voice AI Agent with Open-Source Tools](https://www.freecodecamp.org/news/how-to-build-a-voice-ai-agent-using-open-source-tools/): Hands-on local stack covering open-source STT, a local LLM, and system TTS, plus the cascaded vs end-to-end tradeoff. **🟡 Intermediate**
-- [DeepLearning.AI: Voice for AI Agents and Applications](https://www.deeplearning.ai/courses/voice-for-ai-agents-and-applications): Free short course (June 2026) on three voice integration patterns: embedded, layered on a text agent, and voice as a callable tool. **🟢 Beginner**
+<details>
+<summary><b>10 resources</b></summary>
 
-## 11. GitHub starter repos and awesome lists
+- 🟢 [LiveKit Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Official 10-minute walkthrough in Python or Node with starter templates.
+- 🟢 [Build Your First AI Voice Agent in Python (LiveKit)](https://livekit.com/blog/build-your-first-ai-voice-agent-python): End-to-end Python tutorial covering streaming, latency, and deployment.
+- 🟢 [Pipecat Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart): Build and deploy a Deepgram + OpenAI + Cartesia bot via the Pipecat CLI in roughly 10 minutes.
+- 🟡 [How to Build a Real-Time Voice Agent with Pipecat (AssemblyAI)](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat): Production-oriented walkthrough including local testing and Pipecat Cloud deployment.
+- 🟡 [Build a Voice Agent with LiveKit (AssemblyAI)](https://www.assemblyai.com/blog/build-voice-agent-livekit): End-to-end walkthrough wiring LiveKit Agents + AssemblyAI Universal-3 Pro + Cartesia, run locally then on the Agents Playground.
+- 🟢 [Deepgram: Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent): Step-by-step guide wiring Deepgram STT, GPT, and Aura TTS.
+- 🟡 [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python): Provider-agnostic tutorial supporting OpenAI, Anthropic, or DeepSeek.
+- 🟢 [freeCodeCamp: Build Advanced AI Agents (LiveKit, Exa, LangChain)](https://www.youtube.com/watch?v=B0TJC4lmzEM): Free 3-part video course covering interactive voice agents end-to-end.
+- 🟡 [freeCodeCamp: Build a Voice AI Agent with Open-Source Tools](https://www.freecodecamp.org/news/how-to-build-a-voice-ai-agent-using-open-source-tools/): Hands-on local stack covering open-source STT, a local LLM, and system TTS, plus the cascaded vs end-to-end tradeoff.
+- 🟢 [DeepLearning.AI: Voice for AI Agents and Applications](https://www.deeplearning.ai/courses/voice-for-ai-agents-and-applications): Free short course (June 2026) on three voice integration patterns: embedded, layered on a text agent, and voice as a callable tool.
+
+</details>
+
+## 📦 11. GitHub starter repos and awesome lists
 
 Clone these instead of writing boilerplate from scratch.
 
-- [livekit/agents](https://github.com/livekit/agents): The flagship open-source Python/Node framework for production voice agents (tip: pair it with the LiveKit Docs MCP server and Agent Skill for AI-assisted builds). **🟢 → 🔴**
-- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat): Vendor-neutral framework with 40+ STT/LLM/TTS service plugins. **🟢 → 🔴**
-- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python): Production-ready starter with Dockerfile, eval suite, turn detector, and core plugins. **🟢 Beginner**
-- [livekit-examples (org)](https://github.com/livekit-examples): Official collection of LiveKit Python/React/Swift/Android starters. **🟢 Beginner**
-- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples): Sample apps for push-to-talk, websocket, telephony, and multimodal use cases. **🟢 → 🟡**
-- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples): Runnable Next.js and Python examples for TTS, STT, and real-time agents. **🟢 Beginner**
-- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents): Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs. **🟡 Intermediate**
-- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers): Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers. **🟡 Intermediate**
-- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice): Actively maintained 2026 list of open-source TTS, voice-cloning, and audio/music-generation models. **🟢 Beginner**
+<details>
+<summary><b>9 resources</b></summary>
 
-## 12. Datasets and benchmarks
+- 🟢→🔴 [livekit/agents](https://github.com/livekit/agents): The flagship open-source Python/Node framework for production voice agents (tip: pair it with the LiveKit Docs MCP server and Agent Skill for AI-assisted builds).
+- 🟢→🔴 [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat): Vendor-neutral framework with 40+ STT/LLM/TTS service plugins.
+- 🟢 [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python): Production-ready starter with Dockerfile, eval suite, turn detector, and core plugins.
+- 🟢 [livekit-examples (org)](https://github.com/livekit-examples): Official collection of LiveKit Python/React/Swift/Android starters.
+- 🟢→🟡 [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples): Sample apps for push-to-talk, websocket, telephony, and multimodal use cases.
+- 🟢 [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples): Runnable Next.js and Python examples for TTS, STT, and real-time agents.
+- 🟡 [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents): Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs.
+- 🟡 [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers): Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers.
+- 🟢 [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice): Actively maintained 2026 list of open-source TTS, voice-cloning, and audio/music-generation models.
+
+</details>
+
+## 🗂️ 12. Datasets and benchmarks
 
 You'll rarely train from scratch, but knowing **which dataset a model was trained on** explains its accents, languages, and failure modes.
 
-- [LibriSpeech ASR Corpus](https://www.openslr.org/12): ~1,000 hours of English audiobooks; nearly every ASR paper benchmarks against it. **🟢 Beginner**
-- [Mozilla Common Voice](https://commonvoice.mozilla.org/): Crowdsourced multilingual dataset (100+ languages); the easiest legal way to fine-tune ASR. **🟢 Beginner**
-- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0): One-line `load_dataset()` access for hands-on experiments. The official `mozilla-foundation` releases top out around v17; newer corpus versions (up to v22) are hosted on community mirrors. **🟢 Beginner**
-- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Live comparison of 60+ ASR models on WER and real-time factor. **🟢 Beginner**
-- [Artificial Analysis: Speech](https://artificialanalysis.ai/speech-to-text): Independent benchmarks of commercial STT and TTS providers. **🟢 Beginner**
-- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/): ~24 hours of single-speaker English audio; baseline corpus for Tacotron 2 and VITS. **🟢 Beginner**
-- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443): ~110 English speakers with diverse accents; widely used for multi-speaker TTS. **🟡 Intermediate**
-- [VoxCeleb (Oxford VGG)](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/): Million-utterance "in the wild" dataset for speaker identification and verification. **🟡 Intermediate**
+<details>
+<summary><b>8 resources</b></summary>
 
-## 13. Beginner-accessible research papers
+- 🟢 [LibriSpeech ASR Corpus](https://www.openslr.org/12): ~1,000 hours of English audiobooks; nearly every ASR paper benchmarks against it.
+- 🟢 [Mozilla Common Voice](https://commonvoice.mozilla.org/): Crowdsourced multilingual dataset (100+ languages); the easiest legal way to fine-tune ASR.
+- 🟢 [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0): One-line `load_dataset()` access for hands-on experiments. The official `mozilla-foundation` releases top out around v17; newer corpus versions (up to v22) are hosted on community mirrors.
+- 🟢 [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard): Live comparison of 60+ ASR models on WER and real-time factor.
+- 🟢 [Artificial Analysis: Speech](https://artificialanalysis.ai/speech-to-text): Independent benchmarks of commercial STT and TTS providers.
+- 🟢 [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/): ~24 hours of single-speaker English audio; baseline corpus for Tacotron 2 and VITS.
+- 🟡 [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443): ~110 English speakers with diverse accents; widely used for multi-speaker TTS.
+- 🟡 [VoxCeleb (Oxford VGG)](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/): Million-utterance "in the wild" dataset for speaker identification and verification.
+
+</details>
+
+## 📄 13. Beginner-accessible research papers
 
 These are the **landmark papers behind the models you'll actually use**. Read the Whisper and Common Voice papers first: they're unusually approachable.
 
-- [Whisper: Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356): Behind the most popular open ASR model; unusually clear prose for an ML paper. **🟡 Intermediate**
-- [HuggingFace Whisper fine-tuning blog (companion)](https://huggingface.co/blog/fine-tune-whisper): Hands-on walkthrough that lets you "feel" the Whisper paper in code. **🟢 Beginner**
-- [VITS: Conditional VAE with Adversarial Learning for End-to-End TTS (2021)](https://arxiv.org/abs/2106.06103): The single-stage TTS model behind many open-source voice cloners. **🟡 Intermediate**
-- [Tacotron 2: Natural TTS Synthesis (2017)](https://arxiv.org/abs/1712.05884): Landmark seq2seq + WaveNet-vocoder paper that made neural TTS sound natural. **🟡 Intermediate**
-- [Conformer: Convolution-augmented Transformer for ASR (2020)](https://arxiv.org/abs/2005.08100): The architecture inside NVIDIA Parakeet, Canary, and many leaderboard models. **🟡 Intermediate**
-- [wav2vec 2.0: Self-Supervised Learning of Speech Representations (2020)](https://arxiv.org/abs/2006.11477): Showed that pretraining on unlabeled audio drastically reduces labeled-data needs. **🟡 Intermediate**
-- [Common Voice: A Massively-Multilingual Speech Corpus (2020)](https://arxiv.org/abs/1912.06670): Short, accessible paper describing how Common Voice is built and validated. **🟢 Beginner**
-- [Moshi: A Speech-Text Foundation Model for Real-Time Dialogue (2024)](https://arxiv.org/abs/2410.00037): The first real-time full-duplex spoken LLM; introduces the Mimi codec and the "Inner Monologue" method (time-aligned text before audio tokens). **🔴 Advanced**
-- [Open ASR Leaderboard preprint (2025)](https://arxiv.org/abs/2510.06961): Reproducible benchmark of 60+ ASR models across 11 datasets; the modern landscape map. **🟡 Intermediate**
-- [Full-Duplex-Bench: Evaluating Full-Duplex Spoken Dialogue Models on Turn-Taking (2025)](https://arxiv.org/abs/2503.04721): A reproducible benchmark for interruption handling and turn-taking in speech-to-speech models. **🟡 Intermediate**
+<details>
+<summary><b>10 resources</b></summary>
 
-## 14. Evaluation and testing
+- 🟡 [Whisper: Robust Speech Recognition via Large-Scale Weak Supervision (2022)](https://arxiv.org/abs/2212.04356): Behind the most popular open ASR model; unusually clear prose for an ML paper.
+- 🟢 [HuggingFace Whisper fine-tuning blog (companion)](https://huggingface.co/blog/fine-tune-whisper): Hands-on walkthrough that lets you "feel" the Whisper paper in code.
+- 🟡 [VITS: Conditional VAE with Adversarial Learning for End-to-End TTS (2021)](https://arxiv.org/abs/2106.06103): The single-stage TTS model behind many open-source voice cloners.
+- 🟡 [Tacotron 2: Natural TTS Synthesis (2017)](https://arxiv.org/abs/1712.05884): Landmark seq2seq + WaveNet-vocoder paper that made neural TTS sound natural.
+- 🟡 [Conformer: Convolution-augmented Transformer for ASR (2020)](https://arxiv.org/abs/2005.08100): The architecture inside NVIDIA Parakeet, Canary, and many leaderboard models.
+- 🟡 [wav2vec 2.0: Self-Supervised Learning of Speech Representations (2020)](https://arxiv.org/abs/2006.11477): Showed that pretraining on unlabeled audio drastically reduces labeled-data needs.
+- 🟢 [Common Voice: A Massively-Multilingual Speech Corpus (2020)](https://arxiv.org/abs/1912.06670): Short, accessible paper describing how Common Voice is built and validated.
+- 🔴 [Moshi: A Speech-Text Foundation Model for Real-Time Dialogue (2024)](https://arxiv.org/abs/2410.00037): The first real-time full-duplex spoken LLM; introduces the Mimi codec and the "Inner Monologue" method (time-aligned text before audio tokens).
+- 🟡 [Open ASR Leaderboard preprint (2025)](https://arxiv.org/abs/2510.06961): Reproducible benchmark of 60+ ASR models across 11 datasets; the modern landscape map.
+- 🟡 [Full-Duplex-Bench: Evaluating Full-Duplex Spoken Dialogue Models on Turn-Taking (2025)](https://arxiv.org/abs/2503.04721): A reproducible benchmark for interruption handling and turn-taking in speech-to-speech models.
+
+</details>
+
+## ✅ 14. Evaluation and testing
 
 You can't ship what you can't measure. **Voice-agent evaluation is fundamentally probabilistic**: a single transcript can pass and fail across runs, so simulation and statistics matter more than fixed test cases.
 
-- [Coval: Voice AI Testing Platform](https://www.coval.ai/): Defines the core voice-agent metrics: TTFB, WER, resolution rate, simulated accents, and interruptions. **🟢 Beginner**
-- [Coval: How to Evaluate Voice Agents (Practical Guide)](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance): One of the most cited 2025 guides on probabilistic vs deterministic evaluation. **🟢 Beginner**
-- [Cekura: Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview): Predefined metrics, instruction-following checks, and simulation framework. **🟢 Beginner**
-- [Cekura: Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura): Practical 2025 guide on multi-turn simulation and edge-case generation. **🟡 Intermediate**
-- [Hamming AI](https://hamming.ai/): Production-focused QA platform with simulation, load testing, and 50+ metrics. **🟡 Intermediate**
-- [Hamming: Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide): Reference of latency percentiles, WER, MOS-style quality, and task completion with formulas. **🟡 Intermediate**
-- [LiveKit: Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency): Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize. **🟡 Intermediate**
-- [Twilio: How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents): Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency. **🟢 Beginner**
-- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk): Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation. **🟡 Intermediate**
-- [Future AGI](https://github.com/future-agi/future-agi): Open-source platform to simulate, evaluate, trace, guardrail, and optimize voice and AI agent apps in one feedback loop, with persona-driven simulation and 50+ eval metrics. **🟡 Intermediate**
-- [Roark](https://roark.ai/): Voice-AI QA and observability (YC W25) that turns failed production calls into replayable regression tests. **🟡 Intermediate**
-- [Cekura for Agents (MCP server)](https://www.cekura.ai/blogs/cekura-for-agents): MCP server that lets coding agents (Claude Code, Cursor, Codex) trigger and schedule voice-agent test runs. **🟡 Intermediate**
+<details>
+<summary><b>12 resources</b></summary>
 
-## 15. Production, deployment, and scaling
+- 🟢 [Coval: Voice AI Testing Platform](https://www.coval.ai/): Defines the core voice-agent metrics: TTFB, WER, resolution rate, simulated accents, and interruptions.
+- 🟢 [Coval: How to Evaluate Voice Agents (Practical Guide)](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance): One of the most cited 2025 guides on probabilistic vs deterministic evaluation.
+- 🟢 [Cekura: Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview): Predefined metrics, instruction-following checks, and simulation framework.
+- 🟡 [Cekura: Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura): Practical 2025 guide on multi-turn simulation and edge-case generation.
+- 🟡 [Hamming AI](https://hamming.ai/): Production-focused QA platform with simulation, load testing, and 50+ metrics.
+- 🟡 [Hamming: Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide): Reference of latency percentiles, WER, MOS-style quality, and task completion with formulas.
+- 🟡 [LiveKit: Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency): Per-turn latency metrics (e2e, LLM TTFT, TTS TTFB) and where to optimize.
+- 🟢 [Twilio: How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents): Vendor-neutral 2025 guide arguing for business-outcome metrics over raw WER/latency.
+- 🟡 [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk): Open-source voice AI simulation SDK for testing AI agents; generates synthetic conversations for evaluation.
+- 🟡 [Future AGI](https://github.com/future-agi/future-agi): Open-source platform to simulate, evaluate, trace, guardrail, and optimize voice and AI agent apps in one feedback loop, with persona-driven simulation and 50+ eval metrics.
+- 🟡 [Roark](https://roark.ai/): Voice-AI QA and observability (YC W25) that turns failed production calls into replayable regression tests.
+- 🟡 [Cekura for Agents (MCP server)](https://www.cekura.ai/blogs/cekura-for-agents): MCP server that lets coding agents (Claude Code, Cursor, Codex) trigger and schedule voice-agent test runs.
+
+</details>
+
+## 🚀 15. Production, deployment, and scaling
 
 Real production voice infrastructure is **the hardest unsolved problem in this space**. Read these before quoting anyone a per-minute price.
 
-- [LiveKit: Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/): Real-world write-up on stateful load balancing, autoscaling, and warm pools. **🟡 Intermediate**
-- [LiveKit: Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis): Honest breakdown of what raw model APIs don't give you. **🟡 Intermediate**
-- [Latent Space: OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api): Field-tested guide from Pipecat's creator on Realtime API production realities. **🟡 Intermediate**
-- [TWIML: Building Voice AI Agents That Don't Suck (Kwindla Kramer)](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck): One-hour discussion on real production architecture and turn-taking. **🟡 Intermediate**
-- [AWS: Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/): Full architecture walkthrough including latency optimization and Nova Sonic. **🟡 Intermediate**
-- [Deepgram: STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025): Vendor-by-vendor per-minute economics: required reading before signing any contract. **🟢 Beginner**
-- [Sierra: Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents): Case-study on Sonos, SiriusXM, and OluKai voice deployments. **🟡 Intermediate**
-- [Sierra: Constellation of Models](https://sierra.ai/blog/constellation-of-models): How a leading CX company composes 15+ models per agent. **🟡 Intermediate**
-- [LiveKit Agent Observability](https://livekit.com/products/agent-observability): Built-in tracing, transcripts, and per-stage latency for LiveKit Cloud. **🟢 Beginner**
+<details>
+<summary><b>9 resources</b></summary>
 
-## 16. Ethics, safety, and regulation
+- 🟡 [LiveKit: Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/): Real-world write-up on stateful load balancing, autoscaling, and warm pools.
+- 🟡 [LiveKit: Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis): Honest breakdown of what raw model APIs don't give you.
+- 🟡 [Latent Space: OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api): Field-tested guide from Pipecat's creator on Realtime API production realities.
+- 🟡 [TWIML: Building Voice AI Agents That Don't Suck (Kwindla Kramer)](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck): One-hour discussion on real production architecture and turn-taking.
+- 🟡 [AWS: Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/): Full architecture walkthrough including latency optimization and Nova Sonic.
+- 🟢 [Deepgram: STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025): Vendor-by-vendor per-minute economics: required reading before signing any contract.
+- 🟡 [Sierra: Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents): Case-study on Sonos, SiriusXM, and OluKai voice deployments.
+- 🟡 [Sierra: Constellation of Models](https://sierra.ai/blog/constellation-of-models): How a leading CX company composes 15+ models per agent.
+- 🟢 [LiveKit Agent Observability](https://livekit.com/products/agent-observability): Built-in tracing, transcripts, and per-stage latency for LiveKit Cloud.
+
+</details>
+
+## ⚖️ 16. Ethics, safety, and regulation
 
 If you're shipping a voice agent in 2026, **disclosure and consent are no longer optional**. The FCC and EU AI Act both have teeth.
 
-- [FCC: AI-Generated Voices in Robocalls Illegal (Feb 2024)](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal): The landmark TCPA ruling every U.S. voice-agent dev must read. **🟢 Beginner**
-- [EU AI Act: Article 50 (Transparency for Deepfakes & AI Interactions)](https://artificialintelligenceact.eu/article/50/): Authoritative text of EU disclosure rules; transparency obligations apply from 2 August 2026 (systems already on the market before that date have until 2 December 2026 to comply). **🟡 Intermediate**
-- [European Commission: Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content): Official EU implementation guidance on watermarking and labelling; the finalized Code was published on 10 June 2026. **🟡 Intermediate**
-- [Digital Omnibus on AI: EU AI Act simplification (European Parliament)](https://www.europarl.europa.eu/legislative-train/package-digital-package/file-digital-omnibus-on-ai): June 2026 package (Parliament- and Council-endorsed) adjusting AI Act transparency and timeline obligations; track it for disclosure-rule changes. **🟡 Intermediate**
-- [FTC: Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning): Plain-English summary of the Voice Cloning Challenge winners and Impersonation Rule. **🟢 Beginner**
-- [FTC: Proposed Rule on AI Impersonation of Individuals (Feb 2024)](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals): Direct source on U.S. impersonation-fraud rules covering AI deepfakes. **🟢 Beginner**
-- [Pindrop: Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/): Industry report documenting the sharp rise in deepfake fraud attempts. **🟢 Beginner**
-- [Voice Cloning Ethics (CAMB.AI)](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use): Practical overview of consent frameworks, ELVIS Act, and EU AI Act. **🟢 Beginner**
-- [Detecting AI Audio with SynthID (ElevenLabs)](https://elevenlabs.io/blog/synthid): ElevenLabs adopts Google DeepMind's inaudible SynthID watermark across generated audio and ships a free public Audio Detector. **🟢 Beginner**
-- [NCLC: Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025): Consumer-protection lens on what's actually being enforced. **🟡 Intermediate**
+<details>
+<summary><b>10 resources</b></summary>
 
-## 17. Blogs and newsletters
+- 🟢 [FCC: AI-Generated Voices in Robocalls Illegal (Feb 2024)](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal): The landmark TCPA ruling every U.S. voice-agent dev must read.
+- 🟡 [EU AI Act: Article 50 (Transparency for Deepfakes & AI Interactions)](https://artificialintelligenceact.eu/article/50/): Authoritative text of EU disclosure rules; transparency obligations apply from 2 August 2026 (systems already on the market before that date have until 2 December 2026 to comply).
+- 🟡 [European Commission: Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content): Official EU implementation guidance on watermarking and labelling; the finalized Code was published on 10 June 2026.
+- 🟡 [Digital Omnibus on AI: EU AI Act simplification (European Parliament)](https://www.europarl.europa.eu/legislative-train/package-digital-package/file-digital-omnibus-on-ai): June 2026 package (Parliament- and Council-endorsed) adjusting AI Act transparency and timeline obligations; track it for disclosure-rule changes.
+- 🟢 [FTC: Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning): Plain-English summary of the Voice Cloning Challenge winners and Impersonation Rule.
+- 🟢 [FTC: Proposed Rule on AI Impersonation of Individuals (Feb 2024)](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals): Direct source on U.S. impersonation-fraud rules covering AI deepfakes.
+- 🟢 [Pindrop: Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/): Industry report documenting the sharp rise in deepfake fraud attempts.
+- 🟢 [Voice Cloning Ethics (CAMB.AI)](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use): Practical overview of consent frameworks, ELVIS Act, and EU AI Act.
+- 🟢 [Detecting AI Audio with SynthID (ElevenLabs)](https://elevenlabs.io/blog/synthid): ElevenLabs adopts Google DeepMind's inaudible SynthID watermark across generated audio and ships a free public Audio Detector.
+- 🟡 [NCLC: Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025): Consumer-protection lens on what's actually being enforced.
+
+</details>
+
+## 📰 17. Blogs and newsletters
 
 Subscribe to two or three to stay current: the field moves quickly.
+
+<details>
+<summary><b>9 resources</b></summary>
 
 - [LiveKit Blog](https://livekit.com/blog/): Engineering deep-dives on WebRTC, agents framework releases, and production patterns.
 - [Deepgram Learn](https://deepgram.com/learn): Tutorials on STT/TTS, voice agent design, evals, and pipeline architecture.
@@ -376,14 +480,24 @@ Subscribe to two or three to stay current: the field moves quickly.
 - [Voice AI Newsletter (Krisp)](https://voice-ai-newsletter.krisp.ai/): "Future of Voice AI" interview series with founders.
 - [Voice AI Weekly (Vapi)](https://vapivoice.substack.com/): Weekly Substack rounding up news, products, and tools.
 
-## 18. Podcasts
+</details>
+
+## 🎙️ 18. Podcasts
+
+<details>
+<summary><b>4 resources</b></summary>
 
 - [Deepgram AI Minds](https://deepgram.com/podcast): Founder and builder interviews across the voice AI ecosystem.
 - [The Future of Voice AI (Krisp)](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184): Weekly founder interviews focused on enterprise voice AI architecture.
 - [TWIML AI Podcast: voice episodes](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464): Strong technical interviews; the Kwin Kramer episode is a great starting point.
 - [This Week In Voice (Project Voice)](https://thisweekinvoice.substack.com/): News-roundtable format covering conversational AI.
 
-## 19. Communities
+</details>
+
+## 💬 19. Communities
+
+<details>
+<summary><b>9 resources</b></summary>
 
 - [LiveKit Community Slack](https://livekit.io/join-slack): Direct access to maintainers and other agent builders.
 - [Pipecat Discord](https://discord.com/invite/pipecat): Active community with weekly office hours; invite link from the homepage.
@@ -395,7 +509,12 @@ Subscribe to two or three to stay current: the field moves quickly.
 - [Reddit: r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/): Active threads on local Whisper/Parakeet, on-device TTS, and end-to-end voice stacks.
 - [Reddit: r/AI_Agents](https://www.reddit.com/r/AI_Agents/): General AI-agent community where voice topics surface frequently.
 
-## 20. Conferences and events
+</details>
+
+## 📅 20. Conferences and events
+
+<details>
+<summary><b>6 resources</b></summary>
 
 - [AI Engineer World's Fair](https://www.ai.engineer/worldsfair): Biggest AI-engineering conference; the Voice track has hosted major launches from ElevenLabs, Vapi, LiveKit, Pipecat, and Cartesia. The 2026 edition ran 29 June - 2 July 2026 at Moscone West, San Francisco; session recordings post free to the AI Engineer YouTube channel.
 - [AI Engineer YouTube channel](https://www.youtube.com/@aiDotEngineer): All World's Fair and Summit talks are posted free; the best library of recent voice-AI talks.
@@ -404,12 +523,19 @@ Subscribe to two or three to stay current: the field moves quickly.
 - [AGENTIC AI Summit (Modev, formerly VOICE & AI)](https://gotoagentic.ai/): Long-running Modev voice conference, now broadened to agentic AI; October 5-7, 2026 in Loudoun County, Virginia.
 - [Interspeech 2026](https://interspeech2026.org/): Top academic speech-science conference; intimidating but worth knowing, since most landmark papers debut here. Sydney, Australia, 27 September - 1 October 2026.
 
-## 21. Hackathons and competitions
+</details>
 
-- [ElevenHacks (weekly sprints)](https://hacks.elevenlabs.io/): Weekly themed challenges with credits and prizes; low-pressure way to ship one project per week. **🟢 Beginner**
-- [AI Engineer World's Fair Hackathon](https://cerebralvalley.ai/e/aiewf-hackathon-2026): Co-located with the conference; $10K prizes judged by 3,000+ AI engineers, with a strong voice track; the 2026 edition ran 27-28 June (PDT). **🟡 Intermediate**
-- [lablab.ai AI Hackathons](https://lablab.ai/event): Continuous calendar of short online hackathons frequently sponsored by voice-AI vendors. **🟢 Beginner**
-- [Devpost: Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai): Centralized search for active voice-AI hackathons; the best way to find what's open right now. **🟢 Beginner**
+## 🏆 21. Hackathons and competitions
+
+<details>
+<summary><b>4 resources</b></summary>
+
+- 🟢 [ElevenHacks (weekly sprints)](https://hacks.elevenlabs.io/): Weekly themed challenges with credits and prizes; low-pressure way to ship one project per week.
+- 🟡 [AI Engineer World's Fair Hackathon](https://cerebralvalley.ai/e/aiewf-hackathon-2026): Co-located with the conference; $10K prizes judged by 3,000+ AI engineers, with a strong voice track; the 2026 edition ran 27-28 June (PDT).
+- 🟢 [lablab.ai AI Hackathons](https://lablab.ai/event): Continuous calendar of short online hackathons frequently sponsored by voice-AI vendors.
+- 🟢 [Devpost: Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai): Centralized search for active voice-AI hackathons; the best way to find what's open right now.
+
+</details>
 
 ---
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,319 +52,423 @@
 <details>
 <summary><b>📖 展开全部 21 个章节</b></summary>
 
-1. [基础概念与学习路径](#1-基础概念与学习路径)
-2. [框架与编排平台](#2-框架与编排平台)
-3. [语音转文字（STT / ASR）](#3-语音转文字stt--asr)
-4. [文字转语音（TTS）](#4-文字转语音tts)
-5. [面向语音智能体与实时场景的 LLM](#5-面向语音智能体与实时场景的-llm)
-6. [语音活动检测与话轮转换](#6-语音活动检测与话轮转换)
-7. [音频增强与降噪](#7-音频增强与降噪)
-8. [WebRTC 基础](#8-webrtc-基础)
-9. [电话与 SIP](#9-电话与-sip)
-10. [教程与动手项目](#10-教程与动手项目)
-11. [GitHub 入门仓库与 Awesome 列表](#11-github-入门仓库与-awesome-列表)
-12. [数据集与基准](#12-数据集与基准)
-13. [对初学者友好的研究论文](#13-对初学者友好的研究论文)
-14. [评测与测试](#14-评测与测试)
-15. [生产、部署与扩展](#15-生产部署与扩展)
-16. [伦理、安全与监管](#16-伦理安全与监管)
-17. [博客与通讯](#17-博客与通讯)
-18. [播客](#18-播客)
-19. [社区](#19-社区)
-20. [会议与活动](#20-会议与活动)
-21. [黑客松与竞赛](#21-黑客松与竞赛)
+1. [基础概念与学习路径](#-1-基础概念与学习路径)
+2. [框架与编排平台](#-2-框架与编排平台)
+3. [语音转文字（STT / ASR）](#-3-语音转文字stt--asr)
+4. [文字转语音（TTS）](#-4-文字转语音tts)
+5. [面向语音智能体与实时场景的 LLM](#-5-面向语音智能体与实时场景的-llm)
+6. [语音活动检测与话轮转换](#-6-语音活动检测与话轮转换)
+7. [音频增强与降噪](#-7-音频增强与降噪)
+8. [WebRTC 基础](#-8-webrtc-基础)
+9. [电话与 SIP](#-9-电话与-sip)
+10. [教程与动手项目](#-10-教程与动手项目)
+11. [GitHub 入门仓库与 Awesome 列表](#-11-github-入门仓库与-awesome-列表)
+12. [数据集与基准](#-12-数据集与基准)
+13. [对初学者友好的研究论文](#-13-对初学者友好的研究论文)
+14. [评测与测试](#-14-评测与测试)
+15. [生产、部署与扩展](#-15-生产部署与扩展)
+16. [伦理、安全与监管](#-16-伦理安全与监管)
+17. [博客与通讯](#-17-博客与通讯)
+18. [播客](#-18-播客)
+19. [社区](#-19-社区)
+20. [会议与活动](#-20-会议与活动)
+21. [黑客松与竞赛](#-21-黑客松与竞赛)
 
 </details>
 
 ---
 
-## 1. 基础概念与学习路径
+## 🧭 1. 基础概念与学习路径
 
 从这里开始。下列资源帮你建立**语音智能体流水线的心智模型**，以及职业生涯里会持续打交道的**延迟预算**。
 
-- [语音智能体图解入门（Voice AI & Voice Agents）](https://voiceaiandvoiceagents.com/)：Kwindla Hultman Kramer 的免费、持续更新的长文入门书，可视为本领域的默认教材。**🟢 入门**
-- [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained（LiveKit）](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained)：图解流式模式、话轮检测及延迟主要落在哪些环节。**🟢 入门**
-- [Everything You Need to Know About Voice AI Agents（Deepgram）](https://deepgram.com/learn/everything-about-voice-ai-agents)：端到端入门，涵盖特征提取、ASR、LLM 推理与合成。**🟢 入门**
-- [AI Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/)：权威的「什么是语音智能体」参考，涵盖 Agents 框架、会话（session），以及 STT-LLM-TTS 流水线与实时模型两条路线的取舍。**🟢 入门**
-- [Core Latency in AI Voice Agents（Twilio）](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents)：图解话末检测、静音阈值与智能端点检测（endpointing）。**🟢 入门**
-- [Advice on Building Voice AI in June 2025（Daily.co）](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/)：Pipecat 创始团队给出的 P50/P95 延迟预算实用建议。**🟡 进阶**
-- [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents（AssemblyAI）](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent)：端点检测是最容易被低估的问题；本文是讲得最透的深度文之一。**🟡 进阶**
+<details>
+<summary><b>7 项资源</b></summary>
 
-## 2. 框架与编排平台
+- 🟢 [语音智能体图解入门（Voice AI & Voice Agents）](https://voiceaiandvoiceagents.com/)：Kwindla Hultman Kramer 的免费、持续更新的长文入门书，可视为本领域的默认教材。
+- 🟢 [Voice Agent Architecture: STT, LLM, and TTS Pipelines Explained（LiveKit）](https://livekit.com/blog/voice-agent-architecture-stt-llm-tts-pipelines-explained)：图解流式模式、话轮检测及延迟主要落在哪些环节。
+- 🟢 [Everything You Need to Know About Voice AI Agents（Deepgram）](https://deepgram.com/learn/everything-about-voice-ai-agents)：端到端入门，涵盖特征提取、ASR、LLM 推理与合成。
+- 🟢 [AI Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/)：权威的「什么是语音智能体」参考，涵盖 Agents 框架、会话（session），以及 STT-LLM-TTS 流水线与实时模型两条路线的取舍。
+- 🟢 [Core Latency in AI Voice Agents（Twilio）](https://www.twilio.com/en-us/blog/developers/best-practices/guide-core-latency-ai-voice-agents)：图解话末检测、静音阈值与智能端点检测（endpointing）。
+- 🟡 [Advice on Building Voice AI in June 2025（Daily.co）](https://www.daily.co/blog/advice-on-building-voice-ai-in-june-2025/)：Pipecat 创始团队给出的 P50/P95 延迟预算实用建议。
+- 🟡 [How Intelligent Turn Detection Solves the Biggest Challenge in Voice Agents（AssemblyAI）](https://www.assemblyai.com/blog/turn-detection-endpointing-voice-agent)：端点检测是最容易被低估的问题；本文是讲得最透的深度文之一。
+
+</details>
+
+## 🧩 2. 框架与编排平台
 
 下列框架都能把 STT、LLM 与 TTS 串起来。**若走开源生产路线，LiveKit Agents 与 Pipecat 通常是最稳妥的两款框架**；若偏好托管控制台，Vapi、Retell、Bland 在「从 0 到第一次通话」上非常省时。
 
+| 推荐 | 类型 | 适合 |
+|------|------|------|
+| **LiveKit Agents** | 开源 | 生产、WebRTC 原生 |
+| **Pipecat** | 开源 | 厂商中立的流水线 |
+| **Vapi / Retell / Bland** | 托管 | 最快打通第一通电话 |
+| **OpenAI Realtime / Gemini Live** | 实时 API | 语音到语音 |
+
+<details>
+<summary><b>13 项资源</b></summary>
+
 ### 开源框架
 
-- [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/)：约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。**🟢 入门**
-- [Pipecat：Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI（`uv tool install pipecat-ai-cli`，再 `pipecat init quickstart`）脚手架搭好 Deepgram + OpenAI + Cartesia 流水线；约 5 分钟内可在浏览器里对话。**🟢 入门**
-- [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox)：开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。**🔴 高阶**
-
+- 🟢 [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/)：约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。
+- 🟢 [Pipecat：Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI（`uv tool install pipecat-ai-cli`，再 `pipecat init quickstart`）脚手架搭好 Deepgram + OpenAI + Cartesia 流水线；约 5 分钟内可在浏览器里对话。
+- 🔴 [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox)：开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。
 ### 托管平台
 
-- [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction)：以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。**🟢 入门**
-- [Retell AI：Introduction & Quickstart](https://docs.retellai.com/general/introduction)：电话语音智能体平台，注册送 $10 额度。**🟢 入门**
-- [Bland AI：Send Your First Phone Call](https://www.bland.ai/blog/the-bland-ai-voice-call-api)：极简 API 教程，打出第一通 AI 电话。**🟢 入门**
-- [ElevenLabs Agents：Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart)：约 5 分钟内在任意网站嵌入语音智能体组件（原名「Conversational AI」，现更名为 ElevenAgents）。**🟢 入门**
-
+- 🟢 [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction)：以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。
+- 🟢 [Retell AI：Introduction & Quickstart](https://docs.retellai.com/general/introduction)：电话语音智能体平台，注册送 $10 额度。
+- 🟢 [Bland AI：Send Your First Phone Call](https://www.bland.ai/blog/the-bland-ai-voice-call-api)：极简 API 教程，打出第一通 AI 电话。
+- 🟢 [ElevenLabs Agents：Quickstart](https://elevenlabs.io/docs/eleven-agents/quickstart)：约 5 分钟内在任意网站嵌入语音智能体组件（原名「Conversational AI」，现更名为 ElevenAgents）。
 ### 实时 / 语音到语音 API
 
-- [OpenAI Realtime API：指南](https://developers.openai.com/api/docs/guides/realtime)：`gpt-realtime-2`（GA；GPT-5 级、可配置推理）通过 WebRTC、WebSocket 或 SIP 接入的官方说明。**🟡 进阶**
-- [Google Gemini Live API：概览](https://ai.google.dev/gemini-api/docs/live-api)：低延迟双向语音 + 视觉，支持插话（barge-in）与工具调用，基于 Gemini 原生音频。**🟡 进阶**
-- [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay)：WebSocket 桥接，托管 STT/TTS，你专注 LLM 逻辑；可与任意 LLM 配合。**🟡 进阶**
-
+- 🟡 [OpenAI Realtime API：指南](https://developers.openai.com/api/docs/guides/realtime)：`gpt-realtime-2`（GA；GPT-5 级、可配置推理）通过 WebRTC、WebSocket 或 SIP 接入的官方说明。
+- 🟡 [Google Gemini Live API：概览](https://ai.google.dev/gemini-api/docs/live-api)：低延迟双向语音 + 视觉，支持插话（barge-in）与工具调用，基于 Gemini 原生音频。
+- 🟡 [Twilio ConversationRelay](https://www.twilio.com/docs/voice/conversationrelay)：WebSocket 桥接，托管 STT/TTS，你专注 LLM 逻辑；可与任意 LLM 配合。
 ### 厂商中立对比
 
-- [Vapi vs Pipecat vs LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit)：从架构视角对比流水线控制与传输选型。**🟡 进阶**
-- [11 Voice Agent Platforms Compared（Softcery）](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025)：覆盖面广的市场地图与场景建议。**🟢 入门**
-- [Best Voice Agent Stack（Hamming AI）](https://hamming.ai/resources/best-voice-agent-stack)：自研 vs 采购框架，含具体成本、延迟与上线周期数字。**🟡 进阶**
+- 🟡 [Vapi vs Pipecat vs LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/vapi-vs-pipecat-vs-livekit)：从架构视角对比流水线控制与传输选型。
+- 🟢 [11 Voice Agent Platforms Compared（Softcery）](https://softcery.com/lab/choosing-the-right-voice-agent-platform-in-2025)：覆盖面广的市场地图与场景建议。
+- 🟡 [Best Voice Agent Stack（Hamming AI）](https://hamming.ai/resources/best-voice-agent-stack)：自研 vs 采购框架，含具体成本、延迟与上线周期数字。
 
-## 3. 语音转文字（STT / ASR）
+</details>
 
-**先选定一种流式 STT 并学深**，再四处比价。Deepgram、AssemblyAI 与 Whisper 衍生方案已覆盖多数场景。（像 Deepgram Flux 这类「ASR + 话末检测」一体化模型，参见[话轮转换](#6-语音活动检测与话轮转换)一节。）
+## 🎧 3. 语音转文字（STT / ASR）
+
+**先选定一种流式 STT 并学深**，再四处比价。Deepgram、AssemblyAI 与 Whisper 衍生方案已覆盖多数场景。（像 Deepgram Flux 这类「ASR + 话末检测」一体化模型，参见[话轮转换](#-6-语音活动检测与话轮转换)一节。）
+
+| 推荐 | 类型 | 适合 |
+|------|------|------|
+| **Deepgram Nova-3** | 商业 | 通用，36+ 种语言 |
+| **AssemblyAI Universal-3 Pro** | 商业 | 准确率、话者分离 |
+| **Soniox** | 商业 | 多语言 + 内置翻译 |
+| **faster-whisper** | 开源 | 自托管 Whisper |
+| **NVIDIA Parakeet（NeMo）** | 开源 | 榜单前列准确率 |
+
+<details>
+<summary><b>17 项资源</b></summary>
 
 ### 商业 API
 
-- [Deepgram Nova-3：STT 基准](https://deepgram.com/learn/speech-to-text-benchmarks)：在 WER、延迟与成本语境下介绍 Deepgram 产品；Nova-3 覆盖 36+ 种语言，并支持多语种混说（code-switching）。**🟢 入门**
-- [AssemblyAI Universal-3 Pro Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling)：流式 STT 教程，同时可作为 function calling 示例；Universal-3 Pro Streaming 为当前实时旗舰，新增实时说话人分离与关键术语提示（keyterm prompting）。**🟡 进阶**
-- [OpenAI Whisper / gpt-4o-transcribe API 文档](https://developers.openai.com/api/docs/guides/speech-to-text)：若已用 OpenAI，这是最容易上手的云端 STT。**🟢 入门**
-- [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest)：已 GA 的流式 STT，内置急速话末检测与抗噪能力，搭配 Sonic TTS 组成单供应商低延迟栈。**🟢 入门**
-- [Soniox 语音转文字](https://soniox.com/docs/stt/get-started)：单模型覆盖 60+ 种语言，提供实时 WebSocket 流式与异步 API，支持话者分离、语种识别、话末检测，并内置实时语音翻译（单向或双向）。**🟢 入门**
-- [Speechmatics Melia](https://www.speechmatics.com/company/articles-and-news/introducing-melia-multilingual-speech-to-text-model)：单次前向的多语言 STT，原生多语种混说，覆盖 56+ 种语言。**🟡 进阶**
-- [Gladia Solaria-3](https://www.gladia.io/blog/solaria-3-speech-to-text-model-for-european-languages)：面向嘈杂、多说话人欧洲商务音频优化的 STT（英语生产音频 WER 9.6%）。**🟡 进阶**
-
+- 🟢 [Deepgram Nova-3：STT 基准](https://deepgram.com/learn/speech-to-text-benchmarks)：在 WER、延迟与成本语境下介绍 Deepgram 产品；Nova-3 覆盖 36+ 种语言，并支持多语种混说（code-switching）。
+- 🟡 [AssemblyAI Universal-3 Pro Streaming](https://www.assemblyai.com/blog/build-voice-agent-function-calling)：流式 STT 教程，同时可作为 function calling 示例；Universal-3 Pro Streaming 为当前实时旗舰，新增实时说话人分离与关键术语提示（keyterm prompting）。
+- 🟢 [OpenAI Whisper / gpt-4o-transcribe API 文档](https://developers.openai.com/api/docs/guides/speech-to-text)：若已用 OpenAI，这是最容易上手的云端 STT。
+- 🟢 [Cartesia Ink 2](https://docs.cartesia.ai/build-with-cartesia/stt/latest)：已 GA 的流式 STT，内置急速话末检测与抗噪能力，搭配 Sonic TTS 组成单供应商低延迟栈。
+- 🟢 [Soniox 语音转文字](https://soniox.com/docs/stt/get-started)：单模型覆盖 60+ 种语言，提供实时 WebSocket 流式与异步 API，支持话者分离、语种识别、话末检测，并内置实时语音翻译（单向或双向）。
+- 🟡 [Speechmatics Melia](https://www.speechmatics.com/company/articles-and-news/introducing-melia-multilingual-speech-to-text-model)：单次前向的多语言 STT，原生多语种混说，覆盖 56+ 种语言。
+- 🟡 [Gladia Solaria-3](https://www.gladia.io/blog/solaria-3-speech-to-text-model-for-european-languages)：面向嘈杂、多说话人欧洲商务音频优化的 STT（英语生产音频 WER 9.6%）。
 ### 开源
 
-- [openai/whisper](https://github.com/openai/whisper)：原仓库与 DIY ASR 的事实起点。**🟢 入门**
-- [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper)：基于 CTranslate2 的实现，INT8 下可达约 4× 提速；自托管 Whisper 常用。**🟡 进阶**
-- [NVIDIA NeMo（Parakeet / Canary）](https://github.com/NVIDIA-NeMo/Speech)：榜单前列的开源 ASR 与流式推理方案。**🔴 高阶**
-- [Moonshine](https://github.com/moonshine-ai/moonshine)：轻量端侧 ASR（tiny 27M / base 61M 参数）；v2 新增遍历式（ergodic）流式编码器，面向边缘设备上对延迟敏感的实时转写。**🟡 进阶**
-- [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b)：开放权重、缓存感知的 FastConformer 流式 ASR，覆盖 40 个语言地区，延迟可运行时配置（80 ms 至 1.1 s）。**🔴 高阶**
-
+- 🟢 [openai/whisper](https://github.com/openai/whisper)：原仓库与 DIY ASR 的事实起点。
+- 🟡 [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper)：基于 CTranslate2 的实现，INT8 下可达约 4× 提速；自托管 Whisper 常用。
+- 🔴 [NVIDIA NeMo（Parakeet / Canary）](https://github.com/NVIDIA-NeMo/Speech)：榜单前列的开源 ASR 与流式推理方案。
+- 🟡 [Moonshine](https://github.com/moonshine-ai/moonshine)：轻量端侧 ASR（tiny 27M / base 61M 参数）；v2 新增遍历式（ergodic）流式编码器，面向边缘设备上对延迟敏感的实时转写。
+- 🔴 [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b)：开放权重、缓存感知的 FastConformer 流式 ASR，覆盖 40 个语言地区，延迟可运行时配置（80 ms 至 1.1 s）。
 ### 基准与讲解
 
-- [Open ASR Leaderboard（HuggingFace）](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：社区榜单，11 个数据集；开源选型参考。**🟢 入门**
-- [Artificial Analysis：Speech-to-Text](https://artificialanalysis.ai/speech-to-text)：独立榜单，按 WER、速度与成本排名 48+ 家 STT。**🟢 入门**
-- [Best Speech-to-Text Providers in 2026（Coval）](https://www.coval.ai/blog/best-speech-to-text-providers-in-2026-independent-benchmarks-and-how-to-choose/)：横跨 14 家供应商的独立基准（WER、延迟、话末检测、成本），并指导如何用你自己的真实流量做测试。**🟡 进阶**
-- [Best Speech-to-Text APIs in 2026（Deepgram）](https://deepgram.com/learn/best-speech-to-text-apis-2026)：供应商对比指南；注意作者为商业方。**🟢 入门**
-- [Streaming vs Batch ASR（Arun Baby）](https://www.arunbaby.com/speech-tech/0001-streaming-asr/)：面向工程师的 RNN-T 与 Conformer 流式架构说明。**🟡 进阶**
+- 🟢 [Open ASR Leaderboard（HuggingFace）](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：社区榜单，11 个数据集；开源选型参考。
+- 🟢 [Artificial Analysis：Speech-to-Text](https://artificialanalysis.ai/speech-to-text)：独立榜单，按 WER、速度与成本排名 48+ 家 STT。
+- 🟡 [Best Speech-to-Text Providers in 2026（Coval）](https://www.coval.ai/blog/best-speech-to-text-providers-in-2026-independent-benchmarks-and-how-to-choose/)：横跨 14 家供应商的独立基准（WER、延迟、话末检测、成本），并指导如何用你自己的真实流量做测试。
+- 🟢 [Best Speech-to-Text APIs in 2026（Deepgram）](https://deepgram.com/learn/best-speech-to-text-apis-2026)：供应商对比指南；注意作者为商业方。
+- 🟡 [Streaming vs Batch ASR（Arun Baby）](https://www.arunbaby.com/speech-tech/0001-streaming-asr/)：面向工程师的 RNN-T 与 Conformer 流式架构说明。
 
-## 4. 文字转语音（TTS）
+</details>
+
+## 🗣️ 4. 文字转语音（TTS）
 
 **拖垮语音智能体的往往是延迟，而非单纯音质**——应优先选择真正的流式输出、首字节在 200 ms 以内的供应商。
 
+| 推荐 | 类型 | 适合 |
+|------|------|------|
+| **ElevenLabs** | 商业 | 音质、声音克隆 |
+| **Cartesia Sonic** | 商业 | 面向智能体的最低延迟 |
+| **Deepgram Aura-2** | 商业 | 与 Deepgram STT 搭配 |
+| **Kokoro** | 开源 | 小巧、可跑 CPU |
+| **Chatterbox** | 开源 | 克隆 + 情感控制 |
+
+<details>
+<summary><b>15 项资源</b></summary>
+
 ### 商业 API
 
-- [ElevenLabs 文档](https://elevenlabs.io/docs)：业界领先音质、声音克隆与 Agents 平台同属一套 SDK。**🟢 入门**
-- [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest)：Sonic 3.5（42 种语言，原生话末检测），首字节低于 90 ms，面向语音智能体设计。**🟢 入门**
-- [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models)：低延迟流式 TTS（Aura-2），与 Deepgram STT 衔接顺畅。**🟢 入门**
-- [OpenAI TTS（gpt-4o-mini-tts）](https://developers.openai.com/api/docs/guides/text-to-speech)：OpenAI 栈里最容易接入的 TTS。**🟢 入门**
-- [Soniox 文字转语音](https://soniox.com/docs/tts/get-started)：低延迟流式 TTS（WebSocket，另有 REST API），多语种音色；与 Soniox STT 及翻译搭配，构成单供应商实时语音到语音栈。**🟢 入门**
-- [Artificial Analysis：TTS 榜单](https://artificialanalysis.ai/text-to-speech/models)：ELO、价格与速度对比，含 Rime、PlayHT、Hume、Inworld 等。**🟢 入门**
-- [Best Text-to-Speech Providers in 2026（Coval）](https://www.coval.ai/blog/best-text-to-speech-providers-in-2026-how-to-choose-%28and-why-vendor-benchmarks-lie%29/)：对 14 家 TTS 供应商在延迟、自然度与成本上的独立横评；注意作者为商业方。**🟡 进阶**
-
+- 🟢 [ElevenLabs 文档](https://elevenlabs.io/docs)：业界领先音质、声音克隆与 Agents 平台同属一套 SDK。
+- 🟢 [Cartesia Sonic Quickstart](https://docs.cartesia.ai/build-with-cartesia/tts-models/latest)：Sonic 3.5（42 种语言，原生话末检测），首字节低于 90 ms，面向语音智能体设计。
+- 🟢 [Deepgram Aura-2](https://developers.deepgram.com/docs/tts-models)：低延迟流式 TTS（Aura-2），与 Deepgram STT 衔接顺畅。
+- 🟢 [OpenAI TTS（gpt-4o-mini-tts）](https://developers.openai.com/api/docs/guides/text-to-speech)：OpenAI 栈里最容易接入的 TTS。
+- 🟢 [Soniox 文字转语音](https://soniox.com/docs/tts/get-started)：低延迟流式 TTS（WebSocket，另有 REST API），多语种音色；与 Soniox STT 及翻译搭配，构成单供应商实时语音到语音栈。
+- 🟢 [Artificial Analysis：TTS 榜单](https://artificialanalysis.ai/text-to-speech/models)：ELO、价格与速度对比，含 Rime、PlayHT、Hume、Inworld 等。
+- 🟡 [Best Text-to-Speech Providers in 2026（Coval）](https://www.coval.ai/blog/best-text-to-speech-providers-in-2026-how-to-choose-%28and-why-vendor-benchmarks-lie%29/)：对 14 家 TTS 供应商在延迟、自然度与成本上的独立横评；注意作者为商业方。
 ### 开源
 
-- [Chatterbox（resemble-ai/chatterbox）](https://github.com/resemble-ai/chatterbox)：Resemble AI 的 MIT 许可 TTS，在盲测偏好中胜过 ElevenLabs；约 5 秒零样本声音克隆、情感夸张度控制，并内置 PerTh 水印。Turbo 版（350M）首音频低于 150 ms；多语种版（V3，0.5B）覆盖 23+ 种语言。**🟡 进阶**
-- [Kokoro 82M](https://github.com/hexgrad/kokoro)：体积小、Apache 许可，在社区 ELO 对战中表现突出；可跑 CPU。**🟢 入门**
-- [Piper（OHF-Voice/piper1-gpl）](https://github.com/OHF-Voice/piper1-gpl)：面向树莓派等设备的快速本地神经 TTS，适合离线项目。**🟢 入门**
-- [Coqui TTS（idiap fork）](https://github.com/idiap/coqui-ai-TTS)：Coqui-TTS / XTTS v2 的持续维护分支；依旧实战可靠，但在零样本克隆质量上现已被 Chatterbox 超越。**🟡 进阶**
-- [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS)：基于 Llama-3B 的带情感 TTS，流式时延约 200 ms，支持情感标签。**🟡 进阶**
-- [Sesame CSM](https://github.com/SesameAILabs/csm)：对话向、上下文感知的多说话人 TTS，Llama 骨干 + Mimi 编解码。**🔴 高阶**
-
+- 🟡 [Chatterbox（resemble-ai/chatterbox）](https://github.com/resemble-ai/chatterbox)：Resemble AI 的 MIT 许可 TTS，在盲测偏好中胜过 ElevenLabs；约 5 秒零样本声音克隆、情感夸张度控制，并内置 PerTh 水印。Turbo 版（350M）首音频低于 150 ms；多语种版（V3，0.5B）覆盖 23+ 种语言。
+- 🟢 [Kokoro 82M](https://github.com/hexgrad/kokoro)：体积小、Apache 许可，在社区 ELO 对战中表现突出；可跑 CPU。
+- 🟢 [Piper（OHF-Voice/piper1-gpl）](https://github.com/OHF-Voice/piper1-gpl)：面向树莓派等设备的快速本地神经 TTS，适合离线项目。
+- 🟡 [Coqui TTS（idiap fork）](https://github.com/idiap/coqui-ai-TTS)：Coqui-TTS / XTTS v2 的持续维护分支；依旧实战可靠，但在零样本克隆质量上现已被 Chatterbox 超越。
+- 🟡 [Orpheus-TTS](https://github.com/canopyai/Orpheus-TTS)：基于 Llama-3B 的带情感 TTS，流式时延约 200 ms，支持情感标签。
+- 🔴 [Sesame CSM](https://github.com/SesameAILabs/csm)：对话向、上下文感知的多说话人 TTS，Llama 骨干 + Mimi 编解码。
 ### 流式与伦理
 
-- [Streaming TTS for Low-Latency Agents（Picovoice）](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/)：清晰区分单流、输出流式与双流 TTS。**🟡 进阶**
-- [Ethics of Voice Cloning & Deepfakes（Deepgram）](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes)：厂商中立讨论滥用、监管与开发者责任。**🟢 入门**
+- 🟡 [Streaming TTS for Low-Latency Agents（Picovoice）](https://picovoice.ai/blog/streaming-text-to-speech-for-ai-agents/)：清晰区分单流、输出流式与双流 TTS。
+- 🟢 [Ethics of Voice Cloning & Deepfakes（Deepgram）](https://deepgram.com/learn/ethics-of-voice-cloning-and-deepfakes)：厂商中立讨论滥用、监管与开发者责任。
 
-## 5. 面向语音智能体与实时场景的 LLM
+</details>
+
+## 🧠 5. 面向语音智能体与实时场景的 LLM
 
 用户感知的「是否聪明」很大程度上取决于 **LLM 能多快开始输出第一个 token**。首 token 时延（TTFT）低于约 300 ms 会显著改变对话体感。
 
+<details>
+<summary><b>11 项资源</b></summary>
+
 ### 低延迟推理
 
-- [Groq](https://groq.com/)：LPU 推理云，Llama 吞吐相对常规 GPU 可达约 10×。**🟢 入门**
-- [Cerebras Inference](https://www.cerebras.ai/inference)：晶圆级芯片推理，Llama 类模型吞吐很高。**🟢 入门**
-- [SambaNova Cloud](https://cloud.sambanova.ai/)：可重构数据流架构上的推理服务；低延迟下吞吐稳定。**🟢 入门**
-
+- 🟢 [Groq](https://groq.com/)：LPU 推理云，Llama 吞吐相对常规 GPU 可达约 10×。
+- 🟢 [Cerebras Inference](https://www.cerebras.ai/inference)：晶圆级芯片推理，Llama 类模型吞吐很高。
+- 🟢 [SambaNova Cloud](https://cloud.sambanova.ai/)：可重构数据流架构上的推理服务；低延迟下吞吐稳定。
 ### 语音到语音模型
 
-- [OpenAI Realtime API 指南](https://developers.openai.com/api/docs/guides/realtime)：旗舰级 S2S，传输为 WebRTC/WebSocket（`gpt-realtime-2`，GA）。**🟡 进阶**
-- [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api)：实时多模态语音/视频，支持插话与广泛语言，基于 Gemini 原生音频。**🟡 进阶**
-- [Moshi（kyutai-labs）](https://github.com/kyutai-labs/moshi)：开源全双工语音–文本基础模型（约 200 ms，Mimi 编解码）。Kyutai 更完整的技术栈现已包含 Unmute（级联 STT+LLM+TTS，支持工具调用）、Kyutai STT/TTS 与 Hibiki（流式翻译）。**🔴 高阶**
-- [Speech-to-Speech Models in 2026: Three Architectural Bets（Krzysztof Sopyla）](https://ai.ksopyla.com/posts/voice-to-voice-models-2026-review/)：厂商中立对比全双工（Moshi）、近双工多模态（Qwen-Omni）与级联三种路线，附 FullDuplexBench 数据与取舍。**🟡 进阶**
-
+- 🟡 [OpenAI Realtime API 指南](https://developers.openai.com/api/docs/guides/realtime)：旗舰级 S2S，传输为 WebRTC/WebSocket（`gpt-realtime-2`，GA）。
+- 🟡 [Google Gemini Live](https://ai.google.dev/gemini-api/docs/live-api)：实时多模态语音/视频，支持插话与广泛语言，基于 Gemini 原生音频。
+- 🔴 [Moshi（kyutai-labs）](https://github.com/kyutai-labs/moshi)：开源全双工语音–文本基础模型（约 200 ms，Mimi 编解码）。Kyutai 更完整的技术栈现已包含 Unmute（级联 STT+LLM+TTS，支持工具调用）、Kyutai STT/TTS 与 Hibiki（流式翻译）。
+- 🟡 [Speech-to-Speech Models in 2026: Three Architectural Bets（Krzysztof Sopyla）](https://ai.ksopyla.com/posts/voice-to-voice-models-2026-review/)：厂商中立对比全双工（Moshi）、近双工多模态（Qwen-Omni）与级联三种路线，附 FullDuplexBench 数据与取舍。
 ### 面向语音智能体的提示与工具
 
-- [OpenAI Voice Agents 指南](https://developers.openai.com/api/docs/guides/voice-agents)：对比链式 vs S2S 架构，含提示与工具最佳实践。**🟢 入门**
-- [ElevenLabs Voice Agent Prompting 指南](https://elevenlabs.io/docs/eleven-agents/best-practices/prompting-guide)：面向语音智能体的生产级提示结构，经验可泛化。**🟡 进阶**
-- [Voice AI Prompt Engineering Guide（VoiceInfra）](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide)：解释为何面向语音智能体的提示通常要比聊天场景短约 60–70%，附模板。**🟢 入门**
-- [Tool Definition and Use for Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/logic/tools/definition/)：在语音智能体中定义 `@function_tool` 工具与原始 schema 工具。**🟡 进阶**
+- 🟢 [OpenAI Voice Agents 指南](https://developers.openai.com/api/docs/guides/voice-agents)：对比链式 vs S2S 架构，含提示与工具最佳实践。
+- 🟡 [ElevenLabs Voice Agent Prompting 指南](https://elevenlabs.io/docs/eleven-agents/best-practices/prompting-guide)：面向语音智能体的生产级提示结构，经验可泛化。
+- 🟢 [Voice AI Prompt Engineering Guide（VoiceInfra）](https://voiceinfra.ai/blog/voice-ai-prompt-engineering-complete-guide)：解释为何面向语音智能体的提示通常要比聊天场景短约 60–70%，附模板。
+- 🟡 [Tool Definition and Use for Voice Agents（LiveKit 文档）](https://docs.livekit.io/agents/logic/tools/definition/)：在语音智能体中定义 `@function_tool` 工具与原始 schema 工具。
 
-## 6. 语音活动检测与话轮转换
+</details>
+
+## 🔀 6. 语音活动检测与话轮转换
 
 **仅靠传统 VAD 已不够**——现代方案往往把**声学 VAD**与预测话末的**小型语义模型**（结合用词与韵律）结合起来。
 
-- [Silero VAD](https://github.com/snakers4/silero-vad)：MIT 许可的预训练 VAD；CPU 上每个音频处理块可低至 1 ms 以内。LiveKit 与 Pipecat 中的事实标准。**🟢 入门**
-- [py-webrtcvad](https://github.com/wiseman/py-webrtcvad)：经典 Google WebRTC VAD 的 Python 绑定；轻量基线。**🟢 入门**
-- [LiveKit Turn Detector 博文](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection)：基于小型 Transformer 的话末（EOU）模型如何用语义补足 VAD。**🟡 进阶**
-- [LiveKit turn-detector 模型（HuggingFace）](https://huggingface.co/livekit/turn-detector)：开放权重多语言 EOU 模型，CPU 上以 ONNX 运行，内存占用不足 500 MB。**🟡 进阶**
-- [LiveKit Turn Detector v1.0](https://livekit.com/blog/solving-end-of-turn-detection)：音频原生的话末检测模型（语义 + 声学融合，无需转写），覆盖 14 种语言；现为 LiveKit 默认。**🟡 进阶**
-- [Deepgram Flux](https://deepgram.com/learn/fluxing-conversational-state-and-speech-to-text)：内置话末检测的一体化对话式 STT（话末检测中位数 <300 ms），与 Deepgram 的 Voice Agent API 集成；把 STT 与话轮检测合并到单个模型中。**🟡 进阶**
-- [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/)：基于 Whisper-Tiny 的音频语义 VAD，CPU 上推理很快（按 v3 仓库，约 12 ms / 标准实例），BSD-2 许可。**🟡 进阶**
-- [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn)：模型代码、训练脚本与集成示例（约 8M 参数，Whisper-Tiny 基座）。**🟡 进阶**
-- [Krisp Turn-Taking](https://krisp.ai/)：商业话轮模型，可与任意 STT/LLM/TTS 栈搭配使用。**🟡 进阶**
-- [The Complete Guide to AI Turn-Taking（Tavus）](https://www.tavus.io/blog/ai-turn-taking)：易读总览：纯 VAD 为何在真实对话里失效。**🟢 入门**
-- [Tackling Turn Detection in Voice AI（Notch）](https://www.notch.cx/post/turn-detection-in-voice-ai)：面向工程师的分步导读：VAD 概率、音量与 TTS 标记的组合。**🟡 进阶**
-- [What Is Endpointing in Voice AI?（Cekura）](https://www.cekura.ai/blogs/endpointing-in-voice-ai-turn-detection)：讲解「三信号」话末检测栈，并带测试视角；注意作者为商业方。**🟡 进阶**
-- [Evaluating End-of-Turn Detection Models（Deepgram）](https://deepgram.com/learn/evaluating-end-of-turn-detection-models)：方法论，并对 Flux、Pipecat Smart Turn 与 LiveKit EOU 做正面对比；注意作者为商业方。**🟡 进阶**
-- [ai-coustics VAD](https://developers.ai-coustics.com/)：与实时语音增强、降噪与人声分离打包在同一个音频预处理 SDK 中的 VAD；当你需要同一个组件同时给出清洁后的音频与话轮信号时尤其合适。**🟢 入门**
+<details>
+<summary><b>14 项资源</b></summary>
 
-## 7. 音频增强与降噪
+- 🟢 [Silero VAD](https://github.com/snakers4/silero-vad)：MIT 许可的预训练 VAD；CPU 上每个音频处理块可低至 1 ms 以内。LiveKit 与 Pipecat 中的事实标准。
+- 🟢 [py-webrtcvad](https://github.com/wiseman/py-webrtcvad)：经典 Google WebRTC VAD 的 Python 绑定；轻量基线。
+- 🟡 [LiveKit Turn Detector 博文](https://livekit.com/blog/using-a-transformer-to-improve-end-of-turn-detection)：基于小型 Transformer 的话末（EOU）模型如何用语义补足 VAD。
+- 🟡 [LiveKit turn-detector 模型（HuggingFace）](https://huggingface.co/livekit/turn-detector)：开放权重多语言 EOU 模型，CPU 上以 ONNX 运行，内存占用不足 500 MB。
+- 🟡 [LiveKit Turn Detector v1.0](https://livekit.com/blog/solving-end-of-turn-detection)：音频原生的话末检测模型（语义 + 声学融合，无需转写），覆盖 14 种语言；现为 LiveKit 默认。
+- 🟡 [Deepgram Flux](https://deepgram.com/learn/fluxing-conversational-state-and-speech-to-text)：内置话末检测的一体化对话式 STT（话末检测中位数 <300 ms），与 Deepgram 的 Voice Agent API 集成；把 STT 与话轮检测合并到单个模型中。
+- 🟡 [Pipecat Smart Turn v3](https://www.daily.co/blog/announcing-smart-turn-v3-with-cpu-inference-in-just-12ms/)：基于 Whisper-Tiny 的音频语义 VAD，CPU 上推理很快（按 v3 仓库，约 12 ms / 标准实例），BSD-2 许可。
+- 🟡 [pipecat-ai/smart-turn](https://github.com/pipecat-ai/smart-turn)：模型代码、训练脚本与集成示例（约 8M 参数，Whisper-Tiny 基座）。
+- 🟡 [Krisp Turn-Taking](https://krisp.ai/)：商业话轮模型，可与任意 STT/LLM/TTS 栈搭配使用。
+- 🟢 [The Complete Guide to AI Turn-Taking（Tavus）](https://www.tavus.io/blog/ai-turn-taking)：易读总览：纯 VAD 为何在真实对话里失效。
+- 🟡 [Tackling Turn Detection in Voice AI（Notch）](https://www.notch.cx/post/turn-detection-in-voice-ai)：面向工程师的分步导读：VAD 概率、音量与 TTS 标记的组合。
+- 🟡 [What Is Endpointing in Voice AI?（Cekura）](https://www.cekura.ai/blogs/endpointing-in-voice-ai-turn-detection)：讲解「三信号」话末检测栈，并带测试视角；注意作者为商业方。
+- 🟡 [Evaluating End-of-Turn Detection Models（Deepgram）](https://deepgram.com/learn/evaluating-end-of-turn-detection-models)：方法论，并对 Flux、Pipecat Smart Turn 与 LiveKit EOU 做正面对比；注意作者为商业方。
+- 🟢 [ai-coustics VAD](https://developers.ai-coustics.com/)：与实时语音增强、降噪与人声分离打包在同一个音频预处理 SDK 中的 VAD；当你需要同一个组件同时给出清洁后的音频与话轮信号时尤其合适。
+
+</details>
+
+## 🔊 7. 音频增强与降噪
 
 进入 VAD 与 STT 的音频常常带有噪声、混响或多人声混叠。**在流水线的其他环节之前先把信号清干净**，往往是真实环境（车内、咖啡厅、呼叫中心）下「能上线的语音智能体」与「让用户失望的语音智能体」之间的分水岭。2026 年，每家主流语音 AI 厂商都会在 WebRTC 经典降噪链路之上再叠加一个深度学习降噪器。
 
-- [ai-coustics](https://ai-coustics.com/)：实时语音增强 SDK，提供降噪、人声分离与 VAD；支持端侧与云端部署。参见[文档](https://docs.ai-coustics.com/)与[开发者平台](https://developers.ai-coustics.com/)。**🟢 入门**
-- [Krisp SDK](https://krisp.ai/)：商业级实时降噪与背景人声消除；语音通信领域的事实标准（提供 Python、Node.js、Go、C++ SDK）。LiveKit 的背景人声消除与 Pipecat Cloud 均基于 Krisp。企业接入需通过联系表单。**🟢 入门**
-- [DeepFilterNet（Rikorose/DeepFilterNet）](https://github.com/Rikorose/DeepFilterNet)：开源、低复杂度的全频带实时语音增强；可在嵌入式设备上运行。当前活跃开发中的最强开源降噪器。**🟡 进阶**
-- [RNNoise（xiph/rnnoise）](https://github.com/xiph/rnnoise)：经典的 DSP + 深度学习混合降噪；体积小、易于理解的基线，但已不再活跃维护。**🟡 进阶**
-- [Koala Noise Suppression（Picovoice）](https://picovoice.ai/platform/koala/)：端侧、跨平台的人声分离，自助接入（浏览器、移动端、桌面端、树莓派）。**🟢 入门**
-- [Noise Suppression Guide 2026（Picovoice）](https://picovoice.ai/blog/complete-guide-to-noise-suppression/)：算法、可懂度指标（SII / STI / STOI）与实现取舍；注意作者为商业方。**🟡 进阶**
+<details>
+<summary><b>6 项资源</b></summary>
 
-## 8. WebRTC 基础
+- 🟢 [ai-coustics](https://ai-coustics.com/)：实时语音增强 SDK，提供降噪、人声分离与 VAD；支持端侧与云端部署。参见[文档](https://docs.ai-coustics.com/)与[开发者平台](https://developers.ai-coustics.com/)。
+- 🟢 [Krisp SDK](https://krisp.ai/)：商业级实时降噪与背景人声消除；语音通信领域的事实标准（提供 Python、Node.js、Go、C++ SDK）。LiveKit 的背景人声消除与 Pipecat Cloud 均基于 Krisp。企业接入需通过联系表单。
+- 🟡 [DeepFilterNet（Rikorose/DeepFilterNet）](https://github.com/Rikorose/DeepFilterNet)：开源、低复杂度的全频带实时语音增强；可在嵌入式设备上运行。当前活跃开发中的最强开源降噪器。
+- 🟡 [RNNoise（xiph/rnnoise）](https://github.com/xiph/rnnoise)：经典的 DSP + 深度学习混合降噪；体积小、易于理解的基线，但已不再活跃维护。
+- 🟢 [Koala Noise Suppression（Picovoice）](https://picovoice.ai/platform/koala/)：端侧、跨平台的人声分离，自助接入（浏览器、移动端、桌面端、树莓派）。
+- 🟡 [Noise Suppression Guide 2026（Picovoice）](https://picovoice.ai/blog/complete-guide-to-noise-suppression/)：算法、可懂度指标（SII / STI / STOI）与实现取舍；注意作者为商业方。
+
+</details>
+
+## 🌐 8. WebRTC 基础
 
 对不走电话网的语音智能体，**WebRTC 是默认传输**。要做生产，**ICE、STUN、TURN 与 SFU 架构**不可不晓。
 
-- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)：`RTCPeerConnection`、`getUserMedia` 与信令的权威参考。**🟢 入门**
-- [MDN：WebRTC 协议入门](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols)：ICE、STUN、TURN、SDP 的入门解释。**🟢 入门**
-- [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview)：Google 维护的官方介绍，将 WebRTC 拆为采集与连通。**🟢 入门**
-- [GetStream：WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/)：免费多模块教程，从网络基础到高阶主题。**🟢 入门**
-- [Why WebRTC Beats WebSockets for Voice AI（LiveKit）](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents)：2025 年面向语音智能体构建者的传输对比，用语通俗。**🟡 进阶**
-- [Daily 文档：视频架构入门（P2P vs SFU）](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch)：P2P 与 SFU 最清晰的新手文之一。**🟢 入门**
-- [P2P, SFU, MCU, Hybrid: WebRTC Architecture Guide（Forasoft）](https://www.forasoft.com/blog/article/webrtc-architecture-guide-for-business-2026)：厂商中立的 2026 年四种架构拆解，含当前开源工具（mediasoup、Janus、Jitsi）。**🟡 进阶**
-- [Agora：How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/)：WebRTC 与 WebSocket 对照，附信令示意图。**🟢 入门**
+<details>
+<summary><b>8 项资源</b></summary>
 
-## 9. 电话与 SIP
+- 🟢 [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API)：`RTCPeerConnection`、`getUserMedia` 与信令的权威参考。
+- 🟢 [MDN：WebRTC 协议入门](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Protocols)：ICE、STUN、TURN、SDP 的入门解释。
+- 🟢 [WebRTC.org Getting Started](https://webrtc.org/getting-started/overview)：Google 维护的官方介绍，将 WebRTC 拆为采集与连通。
+- 🟢 [GetStream：WebRTC for the Brave](https://getstream.io/resources/projects/webrtc/)：免费多模块教程，从网络基础到高阶主题。
+- 🟡 [Why WebRTC Beats WebSockets for Voice AI（LiveKit）](https://livekit.com/blog/why-webrtc-beats-websockets-for-voice-ai-agents)：2025 年面向语音智能体构建者的传输对比，用语通俗。
+- 🟢 [Daily 文档：视频架构入门（P2P vs SFU）](https://docs.daily.co/guides/architecture-and-monitoring/intro-to-video-arch)：P2P 与 SFU 最清晰的新手文之一。
+- 🟡 [P2P, SFU, MCU, Hybrid: WebRTC Architecture Guide（Forasoft）](https://www.forasoft.com/blog/article/webrtc-architecture-guide-for-business-2026)：厂商中立的 2026 年四种架构拆解，含当前开源工具（mediasoup、Janus、Jitsi）。
+- 🟢 [Agora：How WebRTC Works](https://www.agora.io/en/blog/how-does-webrtc-work/)：WebRTC 与 WebSocket 对照，附信令示意图。
+
+</details>
+
+## ☎️ 9. 电话与 SIP
 
 电话网与互联网链路上的语音**环境、协议与约束各不相同**。理清 **SIP 中继**如何接入你所用的语音栈（例如基于 LiveKit 或 Pipecat 的部署），才能稳定连接 PSTN。
 
-- [Twilio Programmable Voice](https://www.twilio.com/en-us/voice)：TwiML、Voice API 与 PSTN 一站式；常见起点。**🟢 入门**
-- [Twilio：Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python)：分步教程，把 Twilio Media Streams 接到 LLM，对新手友好。**🟢 入门**
-- [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart)：SIP 基础、SIP Domain 与软电话设置，入门最清楚。**🟢 入门**
-- [Telnyx Voice API](https://telnyx.com/products/voice-api)：强有力的 Twilio 替代，含 WebSocket 媒体流与 AI Assistant 工具。**🟢 入门**
-- [Telnyx：How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk)：SIP trunk 架构、编解码与认证的友好说明。**🟢 入门**
-- [Plivo Voice API 文档](https://www.plivo.com/docs/voice/)：XML 呼叫控制与面向语音智能体的音频流集成。**🟢 入门**
-- [SignalWire Voice 文档](https://signalwire.com/docs/platform/voice)：基于 FreeSWITCH；SWML、类 TwiML API 与语音智能体 SDK（AI Agents SDK）。**🟡 进阶**
-- [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/)：PSTN → 中继 → SIP 服务 → 语音智能体 的最佳示意图说明。**🟢 入门**
-- [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/)：将 Twilio/Telnyx/Plivo/Wavix/Sinch 中继接入 LiveKit 的实操。**🟡 进阶**
-- [Pipecat Telephony Overview](https://docs.pipecat.ai/pipecat/telephony/overview)：基于 WebSocket 的电话与基于 SIP 的呼叫控制之差异。**🟡 进阶**
+| 推荐 | 类型 | 适合 |
+|------|------|------|
+| **Twilio** | 商业 | 默认，生态最大 |
+| **Telnyx / Plivo** | 商业 | 高性价比 SIP 中继 |
+| **SignalWire** | 商业 | 基于 FreeSWITCH，可编程 |
+| **LiveKit SIP / Pipecat** | 框架 | 把中继接入你的智能体 |
 
-## 10. 教程与动手项目
+<details>
+<summary><b>10 项资源</b></summary>
+
+- 🟢 [Twilio Programmable Voice](https://www.twilio.com/en-us/voice)：TwiML、Voice API 与 PSTN 一站式；常见起点。
+- 🟢 [Twilio：Voice AI Assistant with OpenAI Realtime + Python](https://www.twilio.com/en-us/blog/voice-ai-assistant-openai-realtime-api-python)：分步教程，把 Twilio Media Streams 接到 LLM，对新手友好。
+- 🟢 [Twilio SIP Quickstart](https://www.twilio.com/docs/voice/sip/quickstart)：SIP 基础、SIP Domain 与软电话设置，入门最清楚。
+- 🟢 [Telnyx Voice API](https://telnyx.com/products/voice-api)：强有力的 Twilio 替代，含 WebSocket 媒体流与 AI Assistant 工具。
+- 🟢 [Telnyx：How to Set Up a SIP Trunk](https://support.telnyx.com/en/articles/8096455-how-to-configure-a-sip-trunk)：SIP trunk 架构、编解码与认证的友好说明。
+- 🟢 [Plivo Voice API 文档](https://www.plivo.com/docs/voice/)：XML 呼叫控制与面向语音智能体的音频流集成。
+- 🟡 [SignalWire Voice 文档](https://signalwire.com/docs/platform/voice)：基于 FreeSWITCH；SWML、类 TwiML API 与语音智能体 SDK（AI Agents SDK）。
+- 🟢 [LiveKit SIP Primer](https://docs.livekit.io/reference/telephony/sip-primer/)：PSTN → 中继 → SIP 服务 → 语音智能体 的最佳示意图说明。
+- 🟡 [LiveKit SIP Trunk Setup](https://docs.livekit.io/telephony/start/sip-trunk-setup/)：将 Twilio/Telnyx/Plivo/Wavix/Sinch 中继接入 LiveKit 的实操。
+- 🟡 [Pipecat Telephony Overview](https://docs.pipecat.ai/pipecat/telephony/overview)：基于 WebSocket 的电话与基于 SIP 的呼叫控制之差异。
+
+</details>
+
+## 🛠️ 10. 教程与动手项目
 
 **选定一篇教程并做完再开下一篇**。语音智能体对「半成品流水线」极不宽容。
 
-- [LiveKit 语音智能体 Quickstart](https://docs.livekit.io/agents/start/voice-ai/)：官方约 10 分钟 Python/Node 教程与模板。**🟢 入门**
-- [Build Your First AI Voice Agent in Python（LiveKit）](https://livekit.com/blog/build-your-first-ai-voice-agent-python)：端到端 Python：流式、延迟与部署。**🟢 入门**
-- [Pipecat Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI 约 10 分钟搭好并部署 Deepgram + OpenAI + Cartesia 机器人。**🟢 入门**
-- [How to Build a Real-Time Voice Agent with Pipecat（AssemblyAI）](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat)：偏生产：本地测试与 Pipecat Cloud 部署。**🟡 进阶**
-- [Build a Voice Agent with LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/build-voice-agent-livekit)：端到端串联 LiveKit Agents + AssemblyAI Universal-3 Pro + Cartesia，先本地运行再上 Agents Playground。**🟡 进阶**
-- [Deepgram：Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent)：分步串联 Deepgram STT、GPT 与 Aura TTS。**🟢 入门**
-- [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python)：供应商无关，可接 OpenAI、Anthropic 或 DeepSeek。**🟡 进阶**
-- [freeCodeCamp：Build Advanced AI Agents（LiveKit, Exa, LangChain）](https://www.youtube.com/watch?v=B0TJC4lmzEM)：免费三部分视频，端到端交互式语音智能体。**🟢 入门**
-- [freeCodeCamp：Build a Voice AI Agent with Open-Source Tools](https://www.freecodecamp.org/news/how-to-build-a-voice-ai-agent-using-open-source-tools/)：动手搭建本地栈，涵盖开源 STT、本地 LLM 与系统 TTS，并讨论级联 vs 端到端的取舍。**🟡 进阶**
-- [DeepLearning.AI：Voice for AI Agents and Applications](https://www.deeplearning.ai/courses/voice-for-ai-agents-and-applications)：免费短课（2026 年 6 月），讲解三种语音集成模式：内嵌式、叠加在文本智能体之上，以及作为可调用工具。**🟢 入门**
+<details>
+<summary><b>10 项资源</b></summary>
 
-## 11. GitHub 入门仓库与 Awesome 列表
+- 🟢 [LiveKit 语音智能体 Quickstart](https://docs.livekit.io/agents/start/voice-ai/)：官方约 10 分钟 Python/Node 教程与模板。
+- 🟢 [Build Your First AI Voice Agent in Python（LiveKit）](https://livekit.com/blog/build-your-first-ai-voice-agent-python)：端到端 Python：流式、延迟与部署。
+- 🟢 [Pipecat Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI 约 10 分钟搭好并部署 Deepgram + OpenAI + Cartesia 机器人。
+- 🟡 [How to Build a Real-Time Voice Agent with Pipecat（AssemblyAI）](https://www.assemblyai.com/blog/building-a-voice-agent-with-pipecat)：偏生产：本地测试与 Pipecat Cloud 部署。
+- 🟡 [Build a Voice Agent with LiveKit（AssemblyAI）](https://www.assemblyai.com/blog/build-voice-agent-livekit)：端到端串联 LiveKit Agents + AssemblyAI Universal-3 Pro + Cartesia，先本地运行再上 Agents Playground。
+- 🟢 [Deepgram：Build a Voice AI Agent](https://deepgram.com/learn/how-to-build-a-voice-ai-agent)：分步串联 Deepgram STT、GPT 与 Aura TTS。
+- 🟡 [Build a Voice Assistant with Twilio ConversationRelay + LiteLLM](https://www.twilio.com/en-us/blog/developers/tutorials/product/voice-ai-assistant-conversationrelay-litellm-python)：供应商无关，可接 OpenAI、Anthropic 或 DeepSeek。
+- 🟢 [freeCodeCamp：Build Advanced AI Agents（LiveKit, Exa, LangChain）](https://www.youtube.com/watch?v=B0TJC4lmzEM)：免费三部分视频，端到端交互式语音智能体。
+- 🟡 [freeCodeCamp：Build a Voice AI Agent with Open-Source Tools](https://www.freecodecamp.org/news/how-to-build-a-voice-ai-agent-using-open-source-tools/)：动手搭建本地栈，涵盖开源 STT、本地 LLM 与系统 TTS，并讨论级联 vs 端到端的取舍。
+- 🟢 [DeepLearning.AI：Voice for AI Agents and Applications](https://www.deeplearning.ai/courses/voice-for-ai-agents-and-applications)：免费短课（2026 年 6 月），讲解三种语音集成模式：内嵌式、叠加在文本智能体之上，以及作为可调用工具。
+
+</details>
+
+## 📦 11. GitHub 入门仓库与 Awesome 列表
 
 与其从零写样板，不如直接 clone。
 
-- [livekit/agents](https://github.com/livekit/agents)：旗舰级开源 Python/Node 生产语音智能体框架（小贴士：搭配 LiveKit Docs MCP server 与 Agent Skill 可获得 AI 辅助开发）。**🟢 → 🔴**
-- [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat)：厂商中立，含 40+ STT/LLM/TTS 服务插件。**🟢 → 🔴**
-- [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python)：生产向 starter：Dockerfile、评测套件、话轮检测与核心插件。**🟢 入门**
-- [livekit-examples（组织）](https://github.com/livekit-examples)：LiveKit 官方 Python/React/Swift/Android 示例集合。**🟢 入门**
-- [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples)：按键说话、WebSocket、电话与多模态等示例。**🟢 → 🟡**
-- [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples)：可运行的 Next.js 与 Python 示例：TTS、STT 与实时语音智能体。**🟢 入门**
-- [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)：Pipecat 示例：在 M 系列 Mac 上全本地实现端到端语音延迟低于 800 ms。**🟡 进阶**
-- [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)：ASR、TTS、声音转换与语音–LLM 论文索引。**🟡 进阶**
-- [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)：活跃维护的 2026 年开源 TTS、声音克隆与音频/音乐生成模型列表。**🟢 入门**
+<details>
+<summary><b>9 项资源</b></summary>
 
-## 12. 数据集与基准
+- 🟢→🔴 [livekit/agents](https://github.com/livekit/agents)：旗舰级开源 Python/Node 生产语音智能体框架（小贴士：搭配 LiveKit Docs MCP server 与 Agent Skill 可获得 AI 辅助开发）。
+- 🟢→🔴 [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat)：厂商中立，含 40+ STT/LLM/TTS 服务插件。
+- 🟢 [livekit-examples/agent-starter-python](https://github.com/livekit-examples/agent-starter-python)：生产向 starter：Dockerfile、评测套件、话轮检测与核心插件。
+- 🟢 [livekit-examples（组织）](https://github.com/livekit-examples)：LiveKit 官方 Python/React/Swift/Android 示例集合。
+- 🟢→🟡 [pipecat-ai/pipecat-examples](https://github.com/pipecat-ai/pipecat-examples)：按键说话、WebSocket、电话与多模态等示例。
+- 🟢 [elevenlabs/elevenlabs-examples](https://github.com/elevenlabs/elevenlabs-examples)：可运行的 Next.js 与 Python 示例：TTS、STT 与实时语音智能体。
+- 🟡 [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)：Pipecat 示例：在 M 系列 Mac 上全本地实现端到端语音延迟低于 800 ms。
+- 🟡 [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)：ASR、TTS、声音转换与语音–LLM 论文索引。
+- 🟢 [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)：活跃维护的 2026 年开源 TTS、声音克隆与音频/音乐生成模型列表。
+
+</details>
+
+## 🗂️ 12. 数据集与基准
 
 你很少从零训练，但**模型在哪些数据上训练**决定了口音、语言与典型失效模式。
 
-- [LibriSpeech ASR Corpus](https://www.openslr.org/12)：约 1,000 小时英语有声书；大量 ASR 论文以此为基准。**🟢 入门**
-- [Mozilla Common Voice](https://commonvoice.mozilla.org/)：众包多语言（100+）；合法微调 ASR 的最易得途径之一。**🟢 入门**
-- [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0)：一行 `load_dataset()` 做实验。官方 `mozilla-foundation` 版本最高到 v17 左右；更新的语料版本（最高 v22）托管在社区镜像上。**🟢 入门**
-- [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：60+ 模型在 WER 与实时因子上的在线对比。**🟢 入门**
-- [Artificial Analysis：Speech](https://artificialanalysis.ai/speech-to-text)：商业 STT/TTS 的独立基准。**🟢 入门**
-- [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)：约 24 小时单说话人英语；Tacotron 2、VITS 等常用语料。**🟢 入门**
-- [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443)：约 110 位英语说话人，口音多样；多说话人 TTS 常用。**🟡 进阶**
-- [VoxCeleb（Oxford VGG）](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/)：百万级「野外」语句，用于说话人识别与验证。**🟡 进阶**
+<details>
+<summary><b>8 项资源</b></summary>
 
-## 13. 对初学者友好的研究论文
+- 🟢 [LibriSpeech ASR Corpus](https://www.openslr.org/12)：约 1,000 小时英语有声书；大量 ASR 论文以此为基准。
+- 🟢 [Mozilla Common Voice](https://commonvoice.mozilla.org/)：众包多语言（100+）；合法微调 ASR 的最易得途径之一。
+- 🟢 [Common Voice on HuggingFace](https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0)：一行 `load_dataset()` 做实验。官方 `mozilla-foundation` 版本最高到 v17 左右；更新的语料版本（最高 v22）托管在社区镜像上。
+- 🟢 [Open ASR Leaderboard](https://huggingface.co/spaces/hf-audio/open_asr_leaderboard)：60+ 模型在 WER 与实时因子上的在线对比。
+- 🟢 [Artificial Analysis：Speech](https://artificialanalysis.ai/speech-to-text)：商业 STT/TTS 的独立基准。
+- 🟢 [LJSpeech Dataset](https://keithito.com/LJ-Speech-Dataset/)：约 24 小时单说话人英语；Tacotron 2、VITS 等常用语料。
+- 🟡 [VCTK Corpus](https://datashare.ed.ac.uk/handle/10283/3443)：约 110 位英语说话人，口音多样；多说话人 TTS 常用。
+- 🟡 [VoxCeleb（Oxford VGG）](https://www.robots.ox.ac.uk/~vgg/data/voxceleb/)：百万级「野外」语句，用于说话人识别与验证。
+
+</details>
+
+## 📄 13. 对初学者友好的研究论文
 
 这些是**你实际会用到的模型背后的里程碑论文**。建议先看 Whisper 与 Common Voice 两篇——文笔在机器学习论文里算格外友好。
 
-- [Whisper：Robust Speech Recognition via Large-Scale Weak Supervision（2022）](https://arxiv.org/abs/2212.04356)：最流行的开源 ASR 背后；行文比一般 ML 论文清晰。**🟡 进阶**
-- [HuggingFace Whisper 微调博文（配套）](https://huggingface.co/blog/fine-tune-whisper)：动手走一遍，用代码「感受」Whisper 论文。**🟢 入门**
-- [VITS：Conditional VAE with Adversarial Learning for End-to-End TTS（2021）](https://arxiv.org/abs/2106.06103)：许多开源声音克隆器背后的单阶段 TTS。**🟡 进阶**
-- [Tacotron 2：Natural TTS Synthesis（2017）](https://arxiv.org/abs/1712.05884)：seq2seq + WaveNet 声码器的里程碑论文，让神经 TTS 听起来自然。**🟡 进阶**
-- [Conformer：Convolution-augmented Transformer for ASR（2020）](https://arxiv.org/abs/2005.08100)：NVIDIA Parakeet、Canary 及诸多榜单模型内部架构。**🟡 进阶**
-- [wav2vec 2.0：Self-Supervised Learning of Speech Representations（2020）](https://arxiv.org/abs/2006.11477)：证明在无标注音频上预训练可大幅减少标注数据需求。**🟡 进阶**
-- [Common Voice：A Massively-Multilingual Speech Corpus（2020）](https://arxiv.org/abs/1912.06670)：短文，易读，说明 Common Voice 如何构建与校验。**🟢 入门**
-- [Moshi: A Speech-Text Foundation Model for Real-Time Dialogue（2024）](https://arxiv.org/abs/2410.00037)：首个实时全双工口语 LLM；提出 Mimi 编解码与「内心独白」（Inner Monologue，在音频 token 之前对齐输出时间戳文本）方法。**🔴 高阶**
-- [Open ASR Leaderboard preprint（2025）](https://arxiv.org/abs/2510.06961)：60+ 模型、11 个数据集的可复现基准；可作为当前开源 ASR 格局的全景参考。**🟡 进阶**
-- [Full-Duplex-Bench: Evaluating Full-Duplex Spoken Dialogue Models on Turn-Taking（2025）](https://arxiv.org/abs/2503.04721)：用于评测语音到语音模型中打断处理与话轮转换的可复现基准。**🟡 进阶**
+<details>
+<summary><b>10 项资源</b></summary>
 
-## 14. 评测与测试
+- 🟡 [Whisper：Robust Speech Recognition via Large-Scale Weak Supervision（2022）](https://arxiv.org/abs/2212.04356)：最流行的开源 ASR 背后；行文比一般 ML 论文清晰。
+- 🟢 [HuggingFace Whisper 微调博文（配套）](https://huggingface.co/blog/fine-tune-whisper)：动手走一遍，用代码「感受」Whisper 论文。
+- 🟡 [VITS：Conditional VAE with Adversarial Learning for End-to-End TTS（2021）](https://arxiv.org/abs/2106.06103)：许多开源声音克隆器背后的单阶段 TTS。
+- 🟡 [Tacotron 2：Natural TTS Synthesis（2017）](https://arxiv.org/abs/1712.05884)：seq2seq + WaveNet 声码器的里程碑论文，让神经 TTS 听起来自然。
+- 🟡 [Conformer：Convolution-augmented Transformer for ASR（2020）](https://arxiv.org/abs/2005.08100)：NVIDIA Parakeet、Canary 及诸多榜单模型内部架构。
+- 🟡 [wav2vec 2.0：Self-Supervised Learning of Speech Representations（2020）](https://arxiv.org/abs/2006.11477)：证明在无标注音频上预训练可大幅减少标注数据需求。
+- 🟢 [Common Voice：A Massively-Multilingual Speech Corpus（2020）](https://arxiv.org/abs/1912.06670)：短文，易读，说明 Common Voice 如何构建与校验。
+- 🔴 [Moshi: A Speech-Text Foundation Model for Real-Time Dialogue（2024）](https://arxiv.org/abs/2410.00037)：首个实时全双工口语 LLM；提出 Mimi 编解码与「内心独白」（Inner Monologue，在音频 token 之前对齐输出时间戳文本）方法。
+- 🟡 [Open ASR Leaderboard preprint（2025）](https://arxiv.org/abs/2510.06961)：60+ 模型、11 个数据集的可复现基准；可作为当前开源 ASR 格局的全景参考。
+- 🟡 [Full-Duplex-Bench: Evaluating Full-Duplex Spoken Dialogue Models on Turn-Taking（2025）](https://arxiv.org/abs/2503.04721)：用于评测语音到语音模型中打断处理与话轮转换的可复现基准。
+
+</details>
+
+## ✅ 14. 评测与测试
 
 不能度量就无法交付。**语音智能体评测本质上带有随机性**——同一转写在不同次运行中可能过也可能不过，因此**仿真与统计**比固定用例更重要。
 
-- [Coval：Voice AI Testing Platform](https://www.coval.ai/)：定义核心指标：TTFB、WER、解决率、仿真口音与打断等。**🟢 入门**
-- [Coval：How to Evaluate Voice Agents（实用指南）](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance)：2025 年常被引用的概率 vs 确定性评测指南。**🟢 入门**
-- [Cekura：Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview)：预定义指标、指令遵循检查与仿真框架。**🟢 入门**
-- [Cekura：Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura)：2025 实用文：多轮仿真与边界用例生成。**🟡 进阶**
-- [Hamming AI](https://hamming.ai/)：生产向 QA：仿真、负载测试与 50+ 指标。**🟡 进阶**
-- [Hamming：Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide)：延迟百分位数、WER、类 MOS 质量与任务完成率及计算公式。**🟡 进阶**
-- [LiveKit：Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)：每轮延迟（端到端、LLM TTFT、TTS TTFB）与优化切入点。**🟡 进阶**
-- [Twilio：How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)：2025 厂商中立文：主张业务结果指标优于单纯 WER/延迟。**🟢 入门**
-- [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)：开源语音 AI 仿真 SDK，用于测试 AI 智能体；可生成合成对话用于评测。**🟡 进阶**
-- [Future AGI](https://github.com/future-agi/future-agi)：开源平台，在同一反馈闭环中对语音与 AI 智能体应用进行仿真、评测、追踪、护栏与优化；支持基于人物画像的仿真与 50+ 评测指标。**🟡 进阶**
-- [Roark](https://roark.ai/)：语音 AI 的 QA 与可观测性平台（YC W25），把失败的生产通话转化为可重放的回归测试。**🟡 进阶**
-- [Cekura for Agents（MCP server）](https://www.cekura.ai/blogs/cekura-for-agents)：MCP server，让编码智能体（Claude Code、Cursor、Codex）触发并调度语音智能体测试运行。**🟡 进阶**
+<details>
+<summary><b>12 项资源</b></summary>
 
-## 15. 生产、部署与扩展
+- 🟢 [Coval：Voice AI Testing Platform](https://www.coval.ai/)：定义核心指标：TTFB、WER、解决率、仿真口音与打断等。
+- 🟢 [Coval：How to Evaluate Voice Agents（实用指南）](https://www.coval.ai/blog/how-to-evaluate-voice-agents-a-practical-guide-to-testing-and-quality-assurance)：2025 年常被引用的概率 vs 确定性评测指南。
+- 🟢 [Cekura：Metrics Overview](https://docs.cekura.ai/documentation/key-concepts/metrics/overview)：预定义指标、指令遵循检查与仿真框架。
+- 🟡 [Cekura：Performance Testing for Voice Agents](https://www.cekura.ai/blogs/performance-testing-voice-agents-practical-guide-cekura)：2025 实用文：多轮仿真与边界用例生成。
+- 🟡 [Hamming AI](https://hamming.ai/)：生产向 QA：仿真、负载测试与 50+ 指标。
+- 🟡 [Hamming：Voice Agent Evaluation Metrics Guide](https://hamming.ai/resources/voice-agent-evaluation-metrics-guide)：延迟百分位数、WER、类 MOS 质量与任务完成率及计算公式。
+- 🟡 [LiveKit：Understand and Improve Agent Latency](https://livekit.com/blog/understand-and-improve-agent-latency)：每轮延迟（端到端、LLM TTFT、TTS TTFB）与优化切入点。
+- 🟢 [Twilio：How Do You Know if Your Voice AI Agents Are Working?](https://www.twilio.com/en-us/blog/developers/evaluating-voice-ai-agents)：2025 厂商中立文：主张业务结果指标优于单纯 WER/延迟。
+- 🟡 [Future AGI simulate-sdk](https://github.com/future-agi/simulate-sdk)：开源语音 AI 仿真 SDK，用于测试 AI 智能体；可生成合成对话用于评测。
+- 🟡 [Future AGI](https://github.com/future-agi/future-agi)：开源平台，在同一反馈闭环中对语音与 AI 智能体应用进行仿真、评测、追踪、护栏与优化；支持基于人物画像的仿真与 50+ 评测指标。
+- 🟡 [Roark](https://roark.ai/)：语音 AI 的 QA 与可观测性平台（YC W25），把失败的生产通话转化为可重放的回归测试。
+- 🟡 [Cekura for Agents（MCP server）](https://www.cekura.ai/blogs/cekura-for-agents)：MCP server，让编码智能体（Claude Code、Cursor、Codex）触发并调度语音智能体测试运行。
+
+</details>
+
+## 🚀 15. 生产、部署与扩展
 
 语音智能体的生产级基础设施**仍是本领域最难且未完全标准化的问题**。在给人报「每分钟多少钱」之前，建议先读这些。
 
-- [LiveKit：Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/)：有状态负载均衡、自动扩缩与预热池等实战经验。**🟡 进阶**
-- [LiveKit：Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis)：坦率说明「裸调模型 API」缺什么。**🟡 进阶**
-- [Latent Space：OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api)：Pipecat 作者基于一线经验，揭开 Realtime API 在生产环境中的真实面貌。**🟡 进阶**
-- [TWIML：Building Voice AI Agents That Don't Suck（Kwindla Kramer）](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck)：约一小时，谈真实生产架构与话轮。**🟡 进阶**
-- [AWS：Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/)：完整架构含延迟优化与 Nova Sonic。**🟡 进阶**
-- [Deepgram：STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025)：各家每分钟经济性——签合同前必读。**🟢 入门**
-- [Sierra：Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents)：Sonos、SiriusXM、OluKai 等语音智能体部署案例。**🟡 进阶**
-- [Sierra：Constellation of Models](https://sierra.ai/blog/constellation-of-models)：领先客户体验（CX）公司如何在单个语音智能体里组合 15+ 模型。**🟡 进阶**
-- [LiveKit Agent Observability](https://livekit.com/products/agent-observability)：LiveKit Cloud 内置追踪、转写与各阶段延迟。**🟢 入门**
+<details>
+<summary><b>9 项资源</b></summary>
 
-## 16. 伦理、安全与监管
+- 🟡 [LiveKit：Deploy and scale agents on LiveKit Cloud](https://livekit.com/blog/deploy-and-scale-agents-on-livekit-cloud/)：有状态负载均衡、自动扩缩与预热池等实战经验。
+- 🟡 [LiveKit：Why You Shouldn't Build Voice Agents Directly on Model APIs](https://livekit.com/blog/real-time-voice-agents-vs-model-apis)：坦率说明「裸调模型 API」缺什么。
+- 🟡 [Latent Space：OpenAI Realtime API: The Missing Manual](https://www.latent.space/p/realtime-api)：Pipecat 作者基于一线经验，揭开 Realtime API 在生产环境中的真实面貌。
+- 🟡 [TWIML：Building Voice AI Agents That Don't Suck（Kwindla Kramer）](https://twimlai.com/podcast/twimlai/building-voice-ai-agents-that-dont-suck)：约一小时，谈真实生产架构与话轮。
+- 🟡 [AWS：Voice Agents with Pipecat and Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/building-intelligent-ai-voice-agents-with-pipecat-and-amazon-bedrock-part-1/)：完整架构含延迟优化与 Nova Sonic。
+- 🟢 [Deepgram：STT API Pricing Breakdown](https://deepgram.com/learn/speech-to-text-api-pricing-breakdown-2025)：各家每分钟经济性——签合同前必读。
+- 🟡 [Sierra：Shipping and Scaling AI Agents](https://sierra.ai/blog/shipping-and-scaling-ai-agents)：Sonos、SiriusXM、OluKai 等语音智能体部署案例。
+- 🟡 [Sierra：Constellation of Models](https://sierra.ai/blog/constellation-of-models)：领先客户体验（CX）公司如何在单个语音智能体里组合 15+ 模型。
+- 🟢 [LiveKit Agent Observability](https://livekit.com/products/agent-observability)：LiveKit Cloud 内置追踪、转写与各阶段延迟。
+
+</details>
+
+## ⚖️ 16. 伦理、安全与监管
 
 若在 2026 年对外发布语音智能体，**披露与同意已不再是可选项**。FCC 与欧盟《人工智能法》均有实质约束力。
 
-- [FCC：AI-Generated Voices in Robocalls Illegal（2024 年 2 月）](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)：TCPA 里程碑裁定，美国语音智能体开发者应读。**🟢 入门**
-- [EU AI Act：Article 50（深度伪造与 AI 交互的透明度）](https://artificialintelligenceact.eu/article/50/)：欧盟披露规则权威条文；透明度义务自 2026 年 8 月 2 日起适用（在此日期前已上市的系统可延至 2026 年 12 月 2 日合规）。**🟡 进阶**
-- [European Commission：Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content)：官方实施指引：水印与标注；最终版《行为准则》已于 2026 年 6 月 10 日发布。**🟡 进阶**
-- [Digital Omnibus on AI：欧盟 AI 法简化（欧洲议会）](https://www.europarl.europa.eu/legislative-train/package-digital-package/file-digital-omnibus-on-ai)：2026 年 6 月的一揽子方案（经议会与理事会背书），调整 AI 法的透明度与时间线义务；关注其对披露规则的改动。**🟡 进阶**
-- [FTC：Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning)：通俗总结 Voice Cloning Challenge 与冒充规则。**🟢 入门**
-- [FTC：拟议的 AI 个人冒充规则（2024 年 2 月）](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals)：美国冒充欺诈规则的一手来源，涵盖 AI 深度伪造。**🟢 入门**
-- [Pindrop：Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/)：行业报告：深度伪造诈骗尝试急剧上升。**🟢 入门**
-- [Voice Cloning Ethics（CAMB.AI）](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use)：同意框架、ELVIS 法案与欧盟 AI 法的实践概览。**🟢 入门**
-- [Detecting AI Audio with SynthID（ElevenLabs）](https://elevenlabs.io/blog/synthid)：ElevenLabs 在其生成音频中全面采用 Google DeepMind 的不可听 SynthID 水印，并推出免费公开的 Audio Detector。**🟢 入门**
-- [NCLC：Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025)：消费者保护视角看实际执法重点。**🟡 进阶**
+<details>
+<summary><b>10 项资源</b></summary>
 
-## 17. 博客与通讯
+- 🟢 [FCC：AI-Generated Voices in Robocalls Illegal（2024 年 2 月）](https://www.fcc.gov/document/fcc-makes-ai-generated-voices-robocalls-illegal)：TCPA 里程碑裁定，美国语音智能体开发者应读。
+- 🟡 [EU AI Act：Article 50（深度伪造与 AI 交互的透明度）](https://artificialintelligenceact.eu/article/50/)：欧盟披露规则权威条文；透明度义务自 2026 年 8 月 2 日起适用（在此日期前已上市的系统可延至 2026 年 12 月 2 日合规）。
+- 🟡 [European Commission：Code of Practice on AI-Generated Content](https://digital-strategy.ec.europa.eu/en/policies/code-practice-ai-generated-content)：官方实施指引：水印与标注；最终版《行为准则》已于 2026 年 6 月 10 日发布。
+- 🟡 [Digital Omnibus on AI：欧盟 AI 法简化（欧洲议会）](https://www.europarl.europa.eu/legislative-train/package-digital-package/file-digital-omnibus-on-ai)：2026 年 6 月的一揽子方案（经议会与理事会背书），调整 AI 法的透明度与时间线义务；关注其对披露规则的改动。
+- 🟢 [FTC：Approaches to Address AI-Enabled Voice Cloning](https://www.ftc.gov/policy/advocacy-research/tech-at-ftc/2024/04/approaches-address-ai-enabled-voice-cloning)：通俗总结 Voice Cloning Challenge 与冒充规则。
+- 🟢 [FTC：拟议的 AI 个人冒充规则（2024 年 2 月）](https://www.ftc.gov/news-events/news/press-releases/2024/02/ftc-proposes-new-protections-combat-ai-impersonation-individuals)：美国冒充欺诈规则的一手来源，涵盖 AI 深度伪造。
+- 🟢 [Pindrop：Voice Intelligence & Security Report](https://www.pindrop.com/research/report/voice-intelligence-security-report/)：行业报告：深度伪造诈骗尝试急剧上升。
+- 🟢 [Voice Cloning Ethics（CAMB.AI）](https://www.camb.ai/blog-post/voice-cloning-ethics-consent-deepfakes-responsible-ai-voice-use)：同意框架、ELVIS 法案与欧盟 AI 法的实践概览。
+- 🟢 [Detecting AI Audio with SynthID（ElevenLabs）](https://elevenlabs.io/blog/synthid)：ElevenLabs 在其生成音频中全面采用 Google DeepMind 的不可听 SynthID 水印，并推出免费公开的 Audio Detector。
+- 🟡 [NCLC：Top Six TCPA/Robocall Developments 2024/2025](https://library.nclc.org/article/top-six-tcparobocall-developments-20242025)：消费者保护视角看实际执法重点。
+
+</details>
+
+## 📰 17. 博客与通讯
 
 订阅两三份即可跟上节奏——领域变化很快。
+
+<details>
+<summary><b>9 项资源</b></summary>
 
 - [LiveKit Blog](https://livekit.com/blog/)：WebRTC、语音智能体框架发布与生产实践方面的深度技术文章。
 - [Deepgram Learn](https://deepgram.com/learn)：STT/TTS、语音智能体设计、评测与流水线架构教程。
@@ -376,14 +480,24 @@
 - [Voice AI Newsletter（Krisp）](https://voice-ai-newsletter.krisp.ai/)：「Future of Voice AI」创始人访谈系列。
 - [Voice AI Weekly（Vapi）](https://vapivoice.substack.com/)：周报：新闻、产品与工具汇总。
 
-## 18. 播客
+</details>
+
+## 🎙️ 18. 播客
+
+<details>
+<summary><b>4 项资源</b></summary>
 
 - [Deepgram AI Minds](https://deepgram.com/podcast)：语音 AI 生态中的创始人与开发者访谈。
 - [The Future of Voice AI（Krisp）](https://podcasts.apple.com/us/podcast/the-future-of-voice-ai/id1809847184)：每周创始人访谈，侧重企业语音智能体架构。
 - [TWIML AI Podcast：语音相关单集](https://podcasts.apple.com/us/podcast/building-voice-ai-agents-that-dont-suck-with-kwindla-kramer/id1116303051?i=1000717421464)：技术访谈质量高；Kwindla Kramer 集适合入门。
 - [This Week In Voice（Project Voice）](https://thisweekinvoice.substack.com/)：新闻圆桌，覆盖对话式 AI 与语音智能体。
 
-## 19. 社区
+</details>
+
+## 💬 19. 社区
+
+<details>
+<summary><b>9 项资源</b></summary>
 
 - [LiveKit Community Slack](https://livekit.io/join-slack)：直接联系维护者与其他语音智能体开发者。
 - [Pipecat Discord](https://discord.com/invite/pipecat)：活跃社区与每周线上答疑；邀请链接在主页。
@@ -395,7 +509,12 @@
 - [Reddit：r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/)：本地 Whisper/Parakeet、端侧 TTS 与端到端语音栈讨论活跃。
 - [Reddit：r/AI_Agents](https://www.reddit.com/r/AI_Agents/)：通用 AI 智能体社区，语音智能体相关话题常见。
 
-## 20. 会议与活动
+</details>
+
+## 📅 20. 会议与活动
+
+<details>
+<summary><b>6 项资源</b></summary>
 
 - [AI Engineer World's Fair](https://www.ai.engineer/worldsfair)：规模最大的 AI 工程会议；语音智能体分论坛曾有 ElevenLabs、Vapi、LiveKit、Pipecat、Cartesia 等重大发布。2026 年已于 6 月 29 日至 7 月 2 日在旧金山 Moscone West 举办；演讲录像免费发布在 AI Engineer YouTube 频道。
 - [AI Engineer YouTube 频道](https://www.youtube.com/@aiDotEngineer)：World's Fair 与 Summit 演讲免费上线，语音智能体相关演讲的优质资源库。
@@ -404,12 +523,19 @@
 - [AGENTIC AI Summit（Modev，原 VOICE & AI）](https://gotoagentic.ai/)：Modev 旗下长期运行的语音会议，现已扩展至智能体 AI；2026 年 10 月 5-7 日于美国弗吉尼亚州劳登县举办。
 - [Interspeech 2026](https://interspeech2026.org/)：语音科学顶会；门槛高但值得关注，大量里程碑论文首发于此。澳大利亚悉尼，2026 年 9 月 27 日至 10 月 1 日。
 
-## 21. 黑客松与竞赛
+</details>
 
-- [ElevenHacks（每周冲刺）](https://hacks.elevenlabs.io/)：每周主题挑战，含额度与奖品；低压力「一周一项目」。**🟢 入门**
-- [AI Engineer World's Fair Hackathon](https://cerebralvalley.ai/e/aiewf-hackathon-2026)：与大会同期；$10K 奖金，3000+ AI 工程师评审，语音智能体相关项目与竞赛活跃；2026 年场次已于 6 月 27-28 日（PDT）举办。**🟡 进阶**
-- [lablab.ai AI Hackathons](https://lablab.ai/event)：持续更新的短期线上黑客松日历，常有语音智能体厂商赞助。**🟢 入门**
-- [Devpost：Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai)：集中检索进行中的语音智能体黑客松。**🟢 入门**
+## 🏆 21. 黑客松与竞赛
+
+<details>
+<summary><b>4 项资源</b></summary>
+
+- 🟢 [ElevenHacks（每周冲刺）](https://hacks.elevenlabs.io/)：每周主题挑战，含额度与奖品；低压力「一周一项目」。
+- 🟡 [AI Engineer World's Fair Hackathon](https://cerebralvalley.ai/e/aiewf-hackathon-2026)：与大会同期；$10K 奖金，3000+ AI 工程师评审，语音智能体相关项目与竞赛活跃；2026 年场次已于 6 月 27-28 日（PDT）举办。
+- 🟢 [lablab.ai AI Hackathons](https://lablab.ai/event)：持续更新的短期线上黑客松日历，常有语音智能体厂商赞助。
+- 🟢 [Devpost：Voice AI Hackathons](https://devpost.com/hackathons?search=voice+ai)：集中检索进行中的语音智能体黑客松。
+
+</details>
 
 ---
 


### PR DESCRIPTION
## Summary

A readability restructure of both READMEs. **No resources are added or removed** and every link is preserved: this is purely presentation. The diff is large because the difficulty marker moves to the front of most bullet lines, but the changes are mechanical and symmetric across EN and ZH.

## What changed

**Emoji section headers.** Each of the 21 section headings gets a topic emoji (🎧 STT, 🗣️ TTS, ☎️ Telephony, ...). Because GitHub gives an emoji heading a leading-dash anchor slug, the table-of-contents links and the one in-body cross-link (§3 → §6) are **regenerated** so they still resolve. Verified: 0 unresolved anchors in either file.

**Leading difficulty marker.** Each entry now starts with its `🟢`/`🟡`/`🔴` dot instead of a trailing `**🟢 Beginner**`, so the level is scannable down the left edge. The legend up top still defines the colors. Untagged sections (17-19) are unchanged.

**Quick-pick tables.** A small "at a glance" comparison table sits at the top of the four decision sections (Frameworks, STT, TTS, Telephony). Bullets stay underneath, so tooling and the CONTRIBUTING format are untouched.

**Collapsible sections.** Every section is wrapped in a `<details>` block (with a resource count) for a uniform, compact landing page.

## Verification
- EN/ZH parity: **219 links in identical order, 201 entries with identical difficulty tags, 0 mismatches**.
- **All intra-doc anchors resolve** (TOC + cross-link), `<details>` balanced (22/22), no conflict markers.
- Banner, badges, and the resource/PR badge anchors are unaffected.
