### PR TITLE
Add FunASR and SenseVoice STT resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Pick **one streaming STT** and learn it deeply before shopping around. Deepgram,
 | **NVIDIA Parakeet (NeMo)** | Open source | Top-of-leaderboard accuracy |
 
 <details>
-<summary><b>17 resources</b></summary>
+<summary><b>19 resources</b></summary>
 
 ### Commercial APIs
 
@@ -162,6 +162,8 @@ Pick **one streaming STT** and learn it deeply before shopping around. Deepgram,
 - 🟢 [openai/whisper](https://github.com/openai/whisper): The original repo and the de facto starting point for any DIY ASR project.
 - 🟡 [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper): CTranslate2 reimplementation up to 4× faster with INT8; recommended for self-hosted Whisper.
 - 🔴 [NVIDIA NeMo (Parakeet / Canary)](https://github.com/NVIDIA-NeMo/Speech): Top-of-leaderboard open ASR models with streaming inference recipes.
+- 🟡 [FunASR](https://github.com/modelscope/FunASR): Industrial open-source ASR toolkit with Paraformer, SenseVoice, VAD, punctuation, diarization, streaming services, and an OpenAI-compatible API for self-hosted voice agents.
+- 🟡 [SenseVoice](https://github.com/FunAudioLLM/SenseVoice): Multilingual speech understanding model for ASR, language identification, emotion recognition, and audio event detection, with FunASR integration and ONNX/libtorch export examples.
 - 🟡 [Moonshine](https://github.com/moonshine-ai/moonshine): Tiny on-device ASR (tiny 27M / base 61M params); v2 adds an ergodic streaming encoder built for latency-critical live transcription on edge devices.
 - 🔴 [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b): Open-weights cache-aware FastConformer streaming ASR across 40 locales, with runtime-configurable latency (80 ms to 1.1 s).
 ### Benchmarks and explainers

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![License: MIT](https://img.shields.io/github/license/mahimairaja/voiceai?style=flat-square&color=blue)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai/stargazers)
+[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai)
 [![Last commit](https://img.shields.io/github/last-commit/mahimairaja/voiceai?style=flat-square&color=informational)](https://github.com/mahimairaja/voiceai/commits/main)
 [![Resources](https://img.shields.io/badge/resources-200%2B-5b21b6?style=flat-square)](#table-of-contents)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](#contributing)

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![License: MIT](https://img.shields.io/github/license/mahimairaja/voiceai?style=flat-square&color=blue)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai/stargazers)
+[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai)
 [![Last commit](https://img.shields.io/github/last-commit/mahimairaja/voiceai?style=flat-square&color=informational)](https://github.com/mahimairaja/voiceai/commits/main)
 [![Resources](https://img.shields.io/badge/resources-200%2B-5b21b6?style=flat-square)](#目录)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](#贡献)

--- a/README_zh.md
+++ b/README_zh.md
@@ -146,7 +146,7 @@
 | **NVIDIA Parakeet（NeMo）** | 开源 | 榜单前列准确率 |
 
 <details>
-<summary><b>17 项资源</b></summary>
+<summary><b>19 项资源</b></summary>
 
 ### 商业 API
 
@@ -162,6 +162,8 @@
 - 🟢 [openai/whisper](https://github.com/openai/whisper)：原仓库与 DIY ASR 的事实起点。
 - 🟡 [SYSTRAN/faster-whisper](https://github.com/SYSTRAN/faster-whisper)：基于 CTranslate2 的实现，INT8 下可达约 4× 提速；自托管 Whisper 常用。
 - 🔴 [NVIDIA NeMo（Parakeet / Canary）](https://github.com/NVIDIA-NeMo/Speech)：榜单前列的开源 ASR 与流式推理方案。
+- 🟡 [FunASR](https://github.com/modelscope/FunASR)：工业级开源 ASR 工具包，覆盖 Paraformer、SenseVoice、VAD、标点、说话人分离、流式服务与 OpenAI 兼容 API，适合自托管语音智能体。
+- 🟡 [SenseVoice](https://github.com/FunAudioLLM/SenseVoice)：多语种语音理解模型，支持 ASR、语种识别、情感识别和音频事件检测，并提供 FunASR 集成与 ONNX/libtorch 导出示例。
 - 🟡 [Moonshine](https://github.com/moonshine-ai/moonshine)：轻量端侧 ASR（tiny 27M / base 61M 参数）；v2 新增遍历式（ergodic）流式编码器，面向边缘设备上对延迟敏感的实时转写。
 - 🔴 [NVIDIA Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b)：开放权重、缓存感知的 FastConformer 流式 ASR，覆盖 40 个语言地区，延迟可运行时配置（80 ms 至 1.1 s）。
 ### 基准与讲解


### PR DESCRIPTION
## Summary

Adds two open-source STT / ASR resources to both the English and Chinese README files:

- FunASR: industrial open-source ASR toolkit with streaming services and an OpenAI-compatible API
- SenseVoice: multilingual speech understanding model for ASR, language identification, emotion recognition, and audio event detection

The resource count in the STT / ASR section is updated from 17 to 19 in both languages.

## Validation

- `git diff --check`
- confirmed both English and Chinese README files contain the new FunASR and SenseVoice entries
- confirmed the English and Chinese section resource counts both update to 19
- checked the added links return HTTP 200:
  - `https://github.com/modelscope/FunASR`
  - `https://github.com/FunAudioLLM/SenseVoice`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the STT/ASR resource lists in both English and Chinese documentation.
  * Increased the listed open-source resource count from 17 to 19.
  * Added two new resources: FunASR and SenseVoice.
  * Updated the GitHub “Stars” badge link to point to the repository home.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->