### PR TITLE
fix: link stars badge to /stargazers and ignore GitHub stat pages (closes #15)

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,3 +11,6 @@ https://img.shields.io/
 https://awesome.re/
 https://api.star-history.com/
 https://contrib.rocks/
+
+# GitHub stat sub-pages 404 for unauthenticated checkers but load for humans.
+https://github\.com/[^/]+/[^/]+/(stargazers|network|watchers|graphs)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![License: MIT](https://img.shields.io/github/license/mahimairaja/voiceai?style=flat-square&color=blue)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai)
+[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai/stargazers)
 [![Last commit](https://img.shields.io/github/last-commit/mahimairaja/voiceai?style=flat-square&color=informational)](https://github.com/mahimairaja/voiceai/commits/main)
 [![Resources](https://img.shields.io/badge/resources-200%2B-5b21b6?style=flat-square)](#table-of-contents)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](#contributing)

--- a/README_zh.md
+++ b/README_zh.md
@@ -10,7 +10,7 @@
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 [![License: MIT](https://img.shields.io/github/license/mahimairaja/voiceai?style=flat-square&color=blue)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai)
+[![Stars](https://img.shields.io/github/stars/mahimairaja/voiceai?style=flat-square&logo=github&color=yellow)](https://github.com/mahimairaja/voiceai/stargazers)
 [![Last commit](https://img.shields.io/github/last-commit/mahimairaja/voiceai?style=flat-square&color=informational)](https://github.com/mahimairaja/voiceai/commits/main)
 [![Resources](https://img.shields.io/badge/resources-200%2B-5b21b6?style=flat-square)](#目录)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen?style=flat-square)](#贡献)


### PR DESCRIPTION
## Summary

Fixes the broken-link false positive reported in #15.

The header **Stars** badge is repointed to the conventional `/stargazers` page. GitHub returns **404 to unauthenticated/bot requests** for `/stargazers` (and other stat sub-pages) even though the repo has stars and the page loads fine for humans, so the lychee link-checker flagged it and auto-opened #15. A prior commit worked around it by linking the badge to the repo homepage; this restores the correct target and adds a `.lycheeignore` rule so the checker skips GitHub stat sub-pages instead.

## Changes
- `README.md`, `README_zh.md`: Stars badge target `-> /stargazers` (image URL untouched).
- `.lycheeignore`: add `https://github\.com/[^/]+/[^/]+/(stargazers|network|watchers|graphs)` so `/stargazers` and the existing `/graphs/contributors` link are excluded from checking (and any future `/network` / `/watchers` links). Homepage and `/commits/main` links are still checked.

## Verification
- The lychee `link-check` job on this PR should be green, with `/stargazers` and `/graphs/contributors` reported as **Excluded** rather than errored.
- Regex confirmed to match the two stat URLs and to leave the repo homepage and `/commits/main` untouched.

Closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub badge and link behavior so repository star-related links point to the correct public page.
  * Reduced false link-check failures for GitHub stats-style pages during automated checks.
* **Documentation**
  * Updated the README badge link and the Chinese README badge display to match the current GitHub star page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->