### PR TITLE
Add AI-agents-for-dumbphones to section 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Pick **one tutorial and finish it before starting another**. Voice AI is unforgi
 Clone these instead of writing boilerplate from scratch.
 
 <details>
-<summary><b>9 resources</b></summary>
+<summary><b>10 resources</b></summary>
 
 - 🟢→🔴 [livekit/agents](https://github.com/livekit/agents): The flagship open-source Python/Node framework for production voice agents (tip: pair it with the LiveKit Docs MCP server and Agent Skill for AI-assisted builds).
 - 🟢→🔴 [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat): Vendor-neutral framework with 40+ STT/LLM/TTS service plugins.
@@ -363,6 +363,7 @@ Clone these instead of writing boilerplate from scratch.
 - 🟡 [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents): Pipecat example hitting sub-800 ms voice-to-voice latency entirely on M-series Macs.
 - 🟡 [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers): Comprehensive curated index of ASR, TTS, voice conversion, and speech-LLM papers.
 - 🟢 [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice): Actively maintained 2026 list of open-source TTS, voice-cloning, and audio/music-generation models.
+- 🟡 [baptistecristo/AI-agents-for-dumbphones](https://github.com/baptistecristo/AI-agents-for-dumbphones): Apache-2.0 Next.js and Supabase app wrapped around a telephony voice agent, covering the layer above the framework: skills (calendar, reminders, weather), an append-only consent registry, and cron-scheduled outbound calls.
 
 </details>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -352,7 +352,7 @@
 与其从零写样板，不如直接 clone。
 
 <details>
-<summary><b>9 项资源</b></summary>
+<summary><b>10 项资源</b></summary>
 
 - 🟢→🔴 [livekit/agents](https://github.com/livekit/agents)：旗舰级开源 Python/Node 生产语音智能体框架（小贴士：搭配 LiveKit Docs MCP server 与 Agent Skill 可获得 AI 辅助开发）。
 - 🟢→🔴 [pipecat-ai/pipecat](https://github.com/pipecat-ai/pipecat)：厂商中立，含 40+ STT/LLM/TTS 服务插件。
@@ -363,6 +363,7 @@
 - 🟡 [kwindla/macos-local-voice-agents](https://github.com/kwindla/macos-local-voice-agents)：Pipecat 示例：在 M 系列 Mac 上全本地实现端到端语音延迟低于 800 ms。
 - 🟡 [zzw922cn/awesome-speech-recognition-speech-synthesis-papers](https://github.com/zzw922cn/awesome-speech-recognition-speech-synthesis-papers)：ASR、TTS、声音转换与语音–LLM 论文索引。
 - 🟢 [wildminder/awesome-ai-voice](https://github.com/wildminder/awesome-ai-voice)：活跃维护的 2026 年开源 TTS、声音克隆与音频/音乐生成模型列表。
+- 🟡 [baptistecristo/AI-agents-for-dumbphones](https://github.com/baptistecristo/AI-agents-for-dumbphones)：Apache-2.0 的 Next.js + Supabase 应用，围绕电话语音智能体构建：技能（日历、提醒、天气）、仅追加的同意记录，以及定时外呼。可作为框架之上应用层的示例。
 
 </details>
 


### PR DESCRIPTION
Adds a phone-callable voice agent app to section 11, in both README.md and README_zh.md, with the resource count bumped from 9 to 10.

Disclosure: I wrote it, and you invited this PR by email on 14 July.

Against your contribution bar:
- Active in the last 12 months: yes, open-sourced this week.
- Accessible to developers: yes, Apache-2.0, no signup.
- Vendor-neutral or clearly labeled: it runs on Vapi today, which the entry does not hide.
- Genuinely notable: not yet. It has 1 star. Your CONTRIBUTING holds brand-new and low-traction projects until they have real adoption, and this one fits that description.

Two things the entry does not claim:
- Self-hosted. The Pipecat runtime in the repo has never placed a call, and the README says so.
- SMS. No Twilio account is connected, so the SMS paths do not send.

The Chinese line is my own translation, might be wrong sorry.

Thank you for the help!
Baptiste

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and Chinese resource lists to include a new GitHub project for telephone-based voice agents.
  * Corrected the reported resource count from 9 to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->