### PR TITLE
docs: add qwen-audio-agent to open-source frameworks (EN + ZH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ The frameworks below all let you wire STT, an LLM, and TTS together. **For open-
 | **OpenAI Realtime / Gemini Live** | Realtime API | Speech-to-speech |
 
 <details>
-<summary><b>13 resources</b></summary>
+<summary><b>14 resources</b></summary>
 
 ### Open-source frameworks
 
 - 🟢 [LiveKit Agents: Voice AI Quickstart](https://docs.livekit.io/agents/start/voice-ai/): Working assistant in <10 min via Python or TypeScript, runs on top of WebRTC.
 - 🟢 [Pipecat: Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart): Scaffolds a Deepgram + OpenAI + Cartesia pipeline via the Pipecat CLI (`uv tool install pipecat-ai-cli`, then `pipecat init quickstart`); talk to it in the browser in ~5 minutes.
 - 🔴 [Ultravox (fixie-ai/ultravox)](https://github.com/fixie-ai/ultravox): Open-weight multimodal speech LLM (Llama/Gemma/Qwen variants) that skips the separate ASR stage for ~150 ms TTFT.
+- 🟡 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent): Full-duplex voice runtime that drives coding agents (OpenCode, Claude Code, Codex, and other ACP backends) with barge-in, parallel background tasks, and a local wake word.
 ### Managed platforms
 
 - 🟢 [Vapi: Quickstart](https://docs.vapi.ai/quickstart/introduction): Dashboard-first; ship an agent on a free US phone number in under 5 minutes.

--- a/README_zh.md
+++ b/README_zh.md
@@ -107,13 +107,14 @@
 | **OpenAI Realtime / Gemini Live** | 实时 API | 语音到语音 |
 
 <details>
-<summary><b>13 项资源</b></summary>
+<summary><b>14 项资源</b></summary>
 
 ### 开源框架
 
 - 🟢 [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/)：约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。
 - 🟢 [Pipecat：Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI（`uv tool install pipecat-ai-cli`，再 `pipecat init quickstart`）脚手架搭好 Deepgram + OpenAI + Cartesia 流水线；约 5 分钟内可在浏览器里对话。
 - 🔴 [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox)：开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。
+- 🟡 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)：全双工语音运行时，通过 ACP 驱动编码 Agent（OpenCode、Claude Code、Codex 等），支持自然打断、后台任务并行与本地唤醒词。
 ### 托管平台
 
 - 🟢 [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction)：以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。


### PR DESCRIPTION
Adds qwen-audio-agent to section 2 (Frameworks and orchestration platforms / Open-source frameworks), with matching entries in both README.md and README_zh.md, and the resource count bumped from 13 to 14 in both files.

qwen-audio-agent is an active open-source (Apache-2.0) full-duplex voice runtime for coding agents, installable via npm, with no signup required to get value from the self-hosted mode.

Disclosure: I am a maintainer of this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added the `qwen-audio-agent` resource to the open-source frameworks list in the English and Chinese documentation.
  - Updated the listed resource count from 13 to 14.
  - Included details about full-duplex voice runtime, interruption handling, background tasks, and local wake-word support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->