### PR TITLE
docs: fix ZH terminology in the qwen-audio-agent entry and refresh CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,17 @@ If you authored or work on the resource, please disclose that in the pull reques
 2. Add a single bullet that matches the existing format:
 
    ```
-   - [Title](https://link): One-line description of what it is and why it is useful. **🟢 Beginner**
+   - 🟢 [Title](https://link): One-line description of what it is and why it is useful.
    ```
 
-   - The separator between the link and the description is a colon.
-   - Tag the level: **🟢 Beginner**, **🟡 Intermediate**, or **🔴 Advanced**. Blogs, podcasts, and communities (sections 17-19) are left untagged.
-3. **Keep both languages in parity.** Add the matching entry to **both** `README.md` and `README_zh.md`. If you cannot translate it, add the English entry and note in the PR that the Chinese line still needs a translation.
-4. Keep it concise and specific. No marketing language.
+   - The level tag is a single emoji at the start of the bullet: 🟢 beginner, 🟡 intermediate, 🔴 advanced. Blogs, podcasts, and communities (sections 17-19) are left untagged.
+   - The separator between the link and the description is a colon, and the description ends with a period.
+3. Bump the resource count in that section's `<summary>` line (both languages).
+4. **Keep both languages in parity.** Add the matching entry to **both** `README.md` and `README_zh.md`. If you cannot translate it, add the English entry and note in the PR that the Chinese line still needs a translation.
+
+   - `README_zh.md` uses full-width punctuation: `：` after the link, `、` between listed items, `（）` for parentheses, and `。` to end the line.
+   - Translate "agent" as 智能体. Bare "Agent" is reserved for product names such as LiveKit Agents.
+5. Keep it concise and specific. No marketing language.
 
 ## Reporting issues
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -114,7 +114,7 @@
 - 🟢 [LiveKit Agents：语音智能体快速入门](https://docs.livekit.io/agents/start/voice-ai/)：约 10 分钟内用 Python 或 TypeScript 跑通一个语音智能体示例，底层为 WebRTC。
 - 🟢 [Pipecat：Quickstart](https://docs.pipecat.ai/pipecat/get-started/quickstart)：通过 Pipecat CLI（`uv tool install pipecat-ai-cli`，再 `pipecat init quickstart`）脚手架搭好 Deepgram + OpenAI + Cartesia 流水线；约 5 分钟内可在浏览器里对话。
 - 🔴 [Ultravox（fixie-ai/ultravox）](https://github.com/fixie-ai/ultravox)：开放权重的多模态语音 LLM（Llama/Gemma/Qwen 等变体），省去独立 ASR 环节，首 token 时延（TTFT）约 150 ms。
-- 🟡 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)：全双工语音运行时，通过 ACP 驱动编码 Agent（OpenCode、Claude Code、Codex 等），支持自然打断、后台任务并行与本地唤醒词。
+- 🟡 [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent)：全双工语音运行时，通过 ACP 驱动编码智能体（OpenCode、Claude Code、Codex 等），支持自然打断、后台任务并行与本地唤醒词。
 ### 托管平台
 
 - 🟢 [Vapi：Quickstart](https://docs.vapi.ai/quickstart/introduction)：以控制台为先；约 5 分钟内可在免费美国号码上发布语音智能体。


### PR DESCRIPTION
Two follow-ups from the #20 review.

**1. `README_zh.md:117`: `编码 Agent` -> `编码智能体`.**
The file translates generic "agent" as 智能体 everywhere (64 occurrences), and README_zh.md:425 already renders the identical English phrase from README.md:425 ("coding agents (Claude Code, Cursor, Codex)") as 编码智能体（Claude Code、Cursor、Codex）. The only bare-Latin "Agent(s)" in the file are product names: LiveKit Agents, ElevenLabs Agents, Agents Playground, Agent Skill. This was the first generic use, so it goes back to the house term.

**2. `CONTRIBUTING.md` was documenting the pre-restructure bullet format.**
It still showed the trailing `**🟢 Beginner**` tag. Both READMEs have used a leading emoji tag since the July readability pass, so the doc was pointing new contributors at a format that no longer exists anywhere in the repo. Also documents two rules that were previously unwritten:

- Bump the section `<summary>` count in both files.
- Chinese punctuation (full-width `：` `、` `（）` `。`) and the 智能体 terminology rule.

No content changes to either README beyond the single Chinese line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated resource-submission guidelines with emoji level tags, consistent punctuation, clearer descriptions, resource-count updates, and Chinese-language conventions.
  * Clarified the Chinese translation of “agent” in the contribution instructions.
  * Updated the Chinese README to use “编码智能体” for the `qwen-audio-agent` entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->